### PR TITLE
second regex capture to grab hmr rendered marko files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -363,9 +363,10 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
         );
         html = html.replace(
           /src\s*=\s*(['"])(\\.|(?!\1).)*\.marko(\?t=[0-9]+)\1/gim,
-          (m) => m.slice(0, -1) + browserEntryQuery.replace("?","&") + m.slice(-1)
+          (m) =>
+            m.slice(0, -1) + browserEntryQuery.replace("?", "&") + m.slice(-1)
         );
-        return html
+        return html;
       },
       async transform(source, id, ssr) {
         const query = getMarkoQuery(id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -357,10 +357,15 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
           return html;
         }
 
-        return html.replace(
+        html = html.replace(
           /src\s*=\s*(['"])(\\.|(?!\1).)*\.marko\1/gim,
           (m) => m.slice(0, -1) + browserEntryQuery + m.slice(-1)
         );
+        html = html.replace(
+          /src\s*=\s*(['"])(\\.|(?!\1).)*\.marko(\?t=[0-9]+)\1/gim,
+          (m) => m.slice(0, -1) + browserEntryQuery.replace("?","&") + m.slice(-1)
+        );
+        return html
       },
       async transform(source, id, ssr) {
         const query = getMarkoQuery(id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -357,16 +357,11 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
           return html;
         }
 
-        html = html.replace(
-          /src\s*=\s*(['"])(\\.|(?!\1).)*\.marko\1/gim,
-          (m) => m.slice(0, -1) + browserEntryQuery + m.slice(-1)
+        return html.replace(
+          /(src\s*=\s*(['"])(?:(?!\2).)*\.marko)(?:\?((?:(?!\2).)*))?\2/gim,
+          (_, prefix, quote, query) =>
+            prefix + browserEntryQuery + (query ? "&" + query : "") + quote
         );
-        html = html.replace(
-          /src\s*=\s*(['"])(\\.|(?!\1).)*\.marko(\?t=[0-9]+)\1/gim,
-          (m) =>
-            m.slice(0, -1) + browserEntryQuery.replace("?", "&") + m.slice(-1)
-        );
-        return html;
       },
       async transform(source, id, ssr) {
         const query = getMarkoQuery(id);


### PR DESCRIPTION
##Description

vite HMR builds add a t=____ string to the end of marko files that was failing to match the original regex. so, I added a second one.

## Motivation and Context

HMR refreshes in vite would kill the page until the server was restarted


## Checklist:

- [n/a] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
