### PR TITLE
fix: always pass resolveVirtualDependencies compiler option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,15 +74,6 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
         ...opts.babelConfig?.caller,
       },
     },
-  };
-
-  const ssrConfig: Compiler.Config = {
-    ...baseConfig,
-    output: "html",
-  };
-
-  const domConfig: Compiler.Config = {
-    ...baseConfig,
     resolveVirtualDependency(from, dep) {
       const query = `${virtualFileQuery}&id=${encodeURIComponent(
         dep.virtualPath
@@ -101,6 +92,15 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
       virtualFiles.set(id, dep);
       return `./${path.basename(from) + query}`;
     },
+  };
+
+  const ssrConfig: Compiler.Config = {
+    ...baseConfig,
+    output: "html",
+  };
+
+  const domConfig: Compiler.Config = {
+    ...baseConfig,
     output: "dom",
   };
 


### PR DESCRIPTION
## Description

Updates the compiler options to always pass the `resolveVirtualDependencies` config option.
Previously It was not passed for SSR compilation.

## Motivation and Context

In the future this option may be used to enable native css module support within Marko templates and other features.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
