### PR TITLE
refactor: use internal _vite tag instead of generating code to call __viteRenderAssets

### DIFF
--- a/src/render-assets-transform.ts
+++ b/src/render-assets-transform.ts
@@ -7,14 +7,9 @@ export default (tag: types.NodePath<types.MarkoTag>, t: typeof types) => {
 };
 
 function renderAssetsCall(t: typeof types, slot: string) {
-  return t.markoPlaceholder(
-    t.callExpression(
-      t.memberExpression(
-        t.memberExpression(t.identifier("out"), t.identifier("global")),
-        t.identifier("___viteRenderAssets")
-      ),
-      [t.stringLiteral(slot)]
-    ),
-    false
+  return t.markoTag(
+    t.stringLiteral("_vite"),
+    [t.markoAttribute("slot", t.stringLiteral(slot))],
+    t.markoTagBody()
   );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail.  Include the package name if applicable. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
