### PR TITLE
fix: avoid fs readFile call for browser entry file sources

### DIFF
--- a/.changeset/unlucky-dogs-tap.md
+++ b/.changeset/unlucky-dogs-tap.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Avoid using fs readFile for browser entry. This allows virtual files to be browser entries.


### PR DESCRIPTION
## Description

Avoid using fs readFile for browser entry. This allows virtual files to be browser entries.
