### PR TITLE
fix: avoid using Vite's load api

### DIFF
--- a/.changeset/little-rivers-jog.md
+++ b/.changeset/little-rivers-jog.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Avoid using `.load` api since it seems to cause an issue when there are many entry Marko files.


### PR DESCRIPTION
## Description

Vite's `.load` api in the plugin context seems to have issues. Specifically it was found that when using the Marko plugin with many entry Marko files that it would break when using the `load` api.

Instead this PR saves the entry files sources along with the rest of the server manifest and uses that.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
