### PR TITLE
fix: switch to mutation style for vite config mutations

### DIFF
--- a/.changeset/warm-guests-carry.md
+++ b/.changeset/warm-guests-carry.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Switch to purely using the mutation style for update config in the config hook.

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,6 +191,13 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
           ])
         );
 
+        const optimizeExtensions = (optimizeDeps.extensions ??= []);
+        optimizeExtensions.push(".marko");
+
+        const esbuildOptions = (optimizeDeps.esbuildOptions ??= {});
+        const esbuildPlugins = (esbuildOptions.plugins ??= []);
+        esbuildPlugins.push(esbuildPlugin(compiler, baseConfig));
+
         const ssr = (config.ssr ??= {});
         if (ssr.noExternal !== true) {
           ssr.noExternal = Array.from(
@@ -199,20 +206,6 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
             )
           );
         }
-
-        return {
-          ...config,
-          optimizeDeps: {
-            ...config.optimizeDeps,
-            extensions: [".marko", ...(config.optimizeDeps?.extensions || [])],
-            esbuildOptions: {
-              plugins: [
-                esbuildPlugin(compiler, baseConfig),
-                ...(config.optimizeDeps?.esbuildOptions?.plugins || []),
-              ],
-            },
-          },
-        };
       },
       configureServer(_server) {
         ssrConfig.hot = domConfig.hot = true;


### PR DESCRIPTION
## Description

The Vite config plugin hook exposes two apis. You can either mutate the provided config, or return a new config that is deep merged.

For some reason we were doing both which may have been leading to some issues.

This PR updates the code in that plugin hook to only use the mutation style api.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
