### PR TITLE
feat: Add store option for linked mode builds

### DIFF
--- a/.changeset/dull-candles-brake.md
+++ b/.changeset/dull-candles-brake.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Add store option for linked mode builds

--- a/README.md
+++ b/README.md
@@ -118,6 +118,26 @@ marko({ runtimeId: "MY_MARKO_RUNTIME_ID" });
 
 Set this to `false` to opt out of [linked mode](#linked-mode). When this is false, the plugin will only handle resolving and transforming `.marko` files.
 
+### options.store
+
+Storage mechanism to preserve data between SSR and client builds when building in linked mode. Two implementations are available:
+
+- FileStore _(default)_
+
+  ```js
+  import { FileStore } from "@marko/vite";
+  const store = new FileStore();
+  ```
+
+  Reads/writes data to the file system. Use this when running the SSR and client builds in seperate processes such as when using Vite from the command line or npm scripts.
+
+- MemoryStore
+  ```js
+  import { MemoryStore } from "@marko/vite";
+  const store = new MemoryStore();
+  ```
+  Reads/writes data to memory. This option can be used when building with Vite programatically.
+
 ## Code of Conduct
 
 This project adheres to the [eBay Code of Conduct](./.github/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.

--- a/src/__tests__/fixtures/isomorphic-memory-store/__snapshots__/build.expected.loading.0.html
+++ b/src/__tests__/fixtures/isomorphic-memory-store/__snapshots__/build.expected.loading.0.html
@@ -1,0 +1,9 @@
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: false Clicks: 0
+  </div>
+</div>

--- a/src/__tests__/fixtures/isomorphic-memory-store/__snapshots__/build.expected.loading.1.html
+++ b/src/__tests__/fixtures/isomorphic-memory-store/__snapshots__/build.expected.loading.1.html
@@ -1,0 +1,9 @@
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: true Clicks: 0
+  </div>
+</div>

--- a/src/__tests__/fixtures/isomorphic-memory-store/__snapshots__/build.expected.step-0.0.html
+++ b/src/__tests__/fixtures/isomorphic-memory-store/__snapshots__/build.expected.step-0.0.html
@@ -1,0 +1,9 @@
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: true Clicks: 1
+  </div>
+</div>

--- a/src/__tests__/fixtures/isomorphic-memory-store/__snapshots__/dev.expected.loading.0.html
+++ b/src/__tests__/fixtures/isomorphic-memory-store/__snapshots__/dev.expected.loading.0.html
@@ -1,0 +1,9 @@
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: false Clicks: 0
+  </div>
+</div>

--- a/src/__tests__/fixtures/isomorphic-memory-store/__snapshots__/dev.expected.loading.1.html
+++ b/src/__tests__/fixtures/isomorphic-memory-store/__snapshots__/dev.expected.loading.1.html
@@ -1,0 +1,9 @@
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: true Clicks: 0
+  </div>
+</div>

--- a/src/__tests__/fixtures/isomorphic-memory-store/__snapshots__/dev.expected.step-0.0.html
+++ b/src/__tests__/fixtures/isomorphic-memory-store/__snapshots__/dev.expected.step-0.0.html
@@ -1,0 +1,9 @@
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: true Clicks: 1
+  </div>
+</div>

--- a/src/__tests__/fixtures/isomorphic-memory-store/dev-server.js
+++ b/src/__tests__/fixtures/isomorphic-memory-store/dev-server.js
@@ -1,0 +1,33 @@
+// In dev we'll start a Vite dev server in middleware mode,
+// and forward requests to our http request handler.
+
+const { createServer } = require("vite");
+const { join } = require("path");
+const markoPlugin = require("../../..").default;
+
+module.exports = (async () => {
+  const devServer = await createServer({
+    root: __dirname,
+    appType: "custom",
+    logLevel: "silent",
+    plugins: [markoPlugin()],
+    optimizeDeps: { force: true },
+    server: {
+      middlewareMode: true,
+      watch: {
+        ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
+      },
+    },
+  });
+  return devServer.middlewares.use(async (req, res, next) => {
+    try {
+      const { handler } = await devServer.ssrLoadModule(
+        join(__dirname, "./src/index.js")
+      );
+      await handler(req, res, next);
+    } catch (err) {
+      devServer.ssrFixStacktrace(err);
+      return next(err);
+    }
+  });
+})();

--- a/src/__tests__/fixtures/isomorphic-memory-store/server.js
+++ b/src/__tests__/fixtures/isomorphic-memory-store/server.js
@@ -1,0 +1,11 @@
+// In production, simply start up the http server.
+const path = require("path");
+const { createServer } = require("http");
+const serve = require("serve-handler");
+const { handler } = require("./dist/index.mjs");
+const serveOpts = { public: path.resolve(__dirname, "dist") };
+module.exports = createServer(async (req, res) => {
+  await handler(req, res);
+  if (res.headersSent) return;
+  await serve(req, res, serveOpts);
+});

--- a/src/__tests__/fixtures/isomorphic-memory-store/src/components/class-component.marko
+++ b/src/__tests__/fixtures/isomorphic-memory-store/src/components/class-component.marko
@@ -1,0 +1,20 @@
+class {
+  onCreate() {
+    this.state = {
+      clickCount: 0,
+      mounted: false
+    };
+  }
+  onMount() {
+    this.state.mounted = true;
+  }
+
+  handleClick() {
+    this.state.clickCount++;
+  }
+}
+
+<div#clickable onClick("handleClick")>
+  Mounted: ${state.mounted}
+  Clicks: ${state.clickCount}
+</div>

--- a/src/__tests__/fixtures/isomorphic-memory-store/src/components/implicit-component.marko
+++ b/src/__tests__/fixtures/isomorphic-memory-store/src/components/implicit-component.marko
@@ -1,0 +1,9 @@
+static {
+  if (typeof window === "object") {
+    document.body.firstElementChild.append("Loaded Implicit Component");
+  }
+}
+
+<div#implicit>
+  <class-component/>
+</div>

--- a/src/__tests__/fixtures/isomorphic-memory-store/src/components/layout-component.marko
+++ b/src/__tests__/fixtures/isomorphic-memory-store/src/components/layout-component.marko
@@ -1,0 +1,15 @@
+static {
+  if (typeof window === "object") {
+    document.body.firstElementChild.append("Loaded Layout Component");
+  }
+}
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Hello World</title>
+</head>
+<body>
+  <${input.renderBody}/>
+</body>
+</html>

--- a/src/__tests__/fixtures/isomorphic-memory-store/src/index.js
+++ b/src/__tests__/fixtures/isomorphic-memory-store/src/index.js
@@ -1,0 +1,9 @@
+import template from "./template.marko";
+
+export function handler(req, res) {
+  if (req.url === "/") {
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    template.render({}, res);
+  }
+}

--- a/src/__tests__/fixtures/isomorphic-memory-store/src/template.marko
+++ b/src/__tests__/fixtures/isomorphic-memory-store/src/template.marko
@@ -1,0 +1,9 @@
+style {
+  div { color: green }
+}
+
+<layout-component>
+  <div#app>
+    <implicit-component/>
+  </div>
+</layout-component>

--- a/src/__tests__/fixtures/isomorphic-memory-store/test.config.ts
+++ b/src/__tests__/fixtures/isomorphic-memory-store/test.config.ts
@@ -1,0 +1,9 @@
+import { MemoryStore, type Options } from "../../..";
+
+export const ssr = true;
+export async function steps() {
+  await page.click("#clickable");
+}
+export const options: Options = {
+  store: new MemoryStore(),
+};

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -10,7 +10,7 @@ import { JSDOM } from "jsdom";
 import { createRequire } from "module";
 import * as playwright from "playwright";
 import { defaultNormalizer, defaultSerializer } from "@marko/fixture-snapshots";
-import markoPlugin from "..";
+import markoPlugin, { type Options } from "..";
 
 declare global {
   const page: playwright.Page;
@@ -84,6 +84,7 @@ for (const fixture of fs.readdirSync(FIXTURES)) {
     const config = requireCwd(path.join(dir, "test.config.ts")) as {
       ssr: boolean;
       steps?: Step | Step[];
+      options?: Options;
     };
     const steps: Step[] = config.steps
       ? Array.isArray(config.steps)
@@ -105,7 +106,7 @@ for (const fixture of fs.readdirSync(FIXTURES)) {
           root: dir,
           configFile: false,
           logLevel: "silent",
-          plugins: [markoPlugin()],
+          plugins: [markoPlugin(config.options)],
           build: {
             write: true,
             minify: false,
@@ -118,7 +119,7 @@ for (const fixture of fs.readdirSync(FIXTURES)) {
           root: dir,
           configFile: false,
           logLevel: "silent",
-          plugins: [markoPlugin()],
+          plugins: [markoPlugin(config.options)],
           build: {
             write: true,
             minify: false,
@@ -148,7 +149,7 @@ for (const fixture of fs.readdirSync(FIXTURES)) {
           },
           logLevel: "silent",
           optimizeDeps: { force: true },
-          plugins: [markoPlugin({ linked: false })],
+          plugins: [markoPlugin({ ...config.options, linked: false })],
         });
 
         devServer.listen(await getAvailablePort());
@@ -161,7 +162,7 @@ for (const fixture of fs.readdirSync(FIXTURES)) {
           root: dir,
           configFile: false,
           logLevel: "silent",
-          plugins: [markoPlugin({ linked: false })],
+          plugins: [markoPlugin({ ...config.options, linked: false })],
           build: {
             write: true,
             minify: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import type * as vite from "vite";
 import type * as Compiler from "@marko/compiler";
 
-import os from "os";
 import fs from "fs";
 import path from "path";
 import crypto from "crypto";
@@ -16,6 +15,10 @@ import {
   DocManifest,
 } from "./manifest-generator";
 import esbuildPlugin from "./esbuild-plugin";
+import { BuildStore, FileStore } from "./store";
+
+export * from "./store";
+export type { BuildStore } from "./store";
 
 export interface Options {
   // Defaults to true, set to false to disable automatic component discovery and hydration.
@@ -28,6 +31,10 @@ export interface Options {
   translator?: string;
   // Overrides the Babel config that Marko will use.
   babelConfig?: Compiler.Config["babelConfig"];
+  // Store to use between SSR and client builds, defaults to file system
+  store?: BuildStore;
+  // Files to use as client entries - not supported yet
+  entries?: string[];
 }
 
 interface BrowserManifest {
@@ -53,13 +60,13 @@ const queryReg = /\?marko-.+$/;
 const browserEntryQuery = "?marko-browser-entry";
 const serverEntryQuery = "?marko-server-entry";
 const virtualFileQuery = "?marko-virtual";
+const manifestFileName = "manifest.json";
 const markoExt = ".marko";
 const htmlExt = ".html";
 const resolveOpts = { skipSelf: true };
 const cache = new Map<string, Compiler.CompileResult>();
 const thisFile =
   typeof __filename === "string" ? __filename : fileURLToPath(import.meta.url);
-let tempDir: Promise<string> | undefined;
 
 export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
   let compiler: typeof Compiler;
@@ -128,6 +135,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
   let devServer: vite.ViteDevServer;
   let registeredTag: string | false = false;
   let serverManifest: ServerManifest | undefined;
+  let store: BuildStore;
   const entrySources = new Map<string, string>();
   const transformWatchFiles = new Map<string, string[]>();
   const transformOptionalFiles = new Map<string, string[]>();
@@ -144,6 +152,18 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
         devEntryFile = path.join(root, "index.html");
         isBuild = env.command === "build";
         isSSRBuild = isBuild && linked && Boolean(config.build!.ssr);
+        store =
+          opts.store ||
+          new FileStore(
+            `marko-vite-${crypto.createHash("SHA1").update(root).digest("hex")}`
+          );
+
+        // Figure out what else needs to be done to support `entries` option
+        // if (opts.entries) {
+        //   for (const entry in opts.entries) {
+        //     entrySources.set(path.resolve(root, entry), "");
+        //   }
+        // }
 
         if (linked && !registeredTag) {
           // Here we inject either the watchMode vite tag, or the build one.
@@ -237,12 +257,12 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
       },
       async buildStart(inputOptions) {
         if (isBuild && linked && !isSSRBuild) {
-          const serverMetaFile = await getServerManifestFile(root);
-          this.addWatchFile(serverMetaFile);
+          // Is this needed?
+          //this.addWatchFile(serverMetaFile);
 
           try {
             serverManifest = JSON.parse(
-              await fs.promises.readFile(serverMetaFile, "utf-8")
+              (await store.get(manifestFileName))!
             ) as ServerManifest;
             inputOptions.input = toHTMLEntries(root, serverManifest.entries);
             for (const entry in serverManifest.entrySources) {
@@ -489,15 +509,12 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
             }
           }
 
-          await fs.promises.writeFile(
-            await getServerManifestFile(root),
-            JSON.stringify(serverManifest)
-          );
+          await store.set(manifestFileName, JSON.stringify(serverManifest));
         } else {
           const browserManifest: BrowserManifest = {};
 
-          for (const entryId in serverManifest.entries) {
-            const fileName = serverManifest.entries[entryId];
+          for (const entryId in serverManifest!.entries) {
+            const fileName = serverManifest!.entries[entryId];
             let chunkId = fileName + htmlExt;
             let chunk = bundle[chunkId];
 
@@ -525,7 +542,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
             browserManifest
           )};\n`;
 
-          for (const fileName of serverManifest.chunksNeedingAssets) {
+          for (const fileName of serverManifest!.chunksNeedingAssets) {
             await fs.promises.appendFile(fileName, manifestStr);
           }
         }
@@ -555,35 +572,6 @@ function toHTMLEntries(root: string, serverEntries: ServerManifest["entries"]) {
   }
 
   return result;
-}
-
-async function getServerManifestFile(root: string) {
-  return path.join(await getTempDir(root), "manifest.json");
-}
-
-function getTempDir(root: string) {
-  return (
-    tempDir ||
-    (tempDir = (async () => {
-      const dir = path.join(
-        os.tmpdir(),
-        `marko-vite-${crypto.createHash("SHA1").update(root).digest("hex")}`
-      );
-
-      try {
-        const stat = await fs.promises.stat(dir);
-
-        if (stat.isDirectory()) {
-          return dir;
-        }
-      } catch {
-        await fs.promises.mkdir(dir);
-        return dir;
-      }
-
-      throw new Error("Unable to create temp directory");
-    })())
-  );
 }
 
 function toEntryId(id: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,8 +33,6 @@ export interface Options {
   babelConfig?: Compiler.Config["babelConfig"];
   // Store to use between SSR and client builds, defaults to file system
   store?: BuildStore;
-  // Files to use as client entries - not supported yet
-  entries?: string[];
 }
 
 interface BrowserManifest {
@@ -157,13 +155,6 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
           new FileStore(
             `marko-vite-${crypto.createHash("SHA1").update(root).digest("hex")}`
           );
-
-        // Figure out what else needs to be done to support `entries` option
-        // if (opts.entries) {
-        //   for (const entry in opts.entries) {
-        //     entrySources.set(path.resolve(root, entry), "");
-        //   }
-        // }
 
         if (linked && !registeredTag) {
           // Here we inject either the watchMode vite tag, or the build one.

--- a/src/store/__tests__/file-store.test.ts
+++ b/src/store/__tests__/file-store.test.ts
@@ -1,0 +1,56 @@
+import fs from "fs";
+import assert from "assert";
+import FileStore from "../file-store";
+
+let store: FileStore;
+beforeEach(() => {
+  store = new FileStore("test");
+});
+
+afterEach(async () => {
+  try {
+    const dir = await store._temp;
+    if (dir) {
+      await fs.promises.rm(dir, { recursive: true, force: true });
+    }
+  } catch (err) {
+    // do nothing
+  }
+});
+
+describe("file store should", () => {
+  it("allow retrieving data", async () => {
+    const expectedKey = "hello";
+    const expectedData = "world";
+
+    await store.set(expectedKey, expectedData);
+
+    assert.equal(await store.get(expectedKey), expectedData);
+    assert.equal(await store.get("non-existing key"), undefined);
+  });
+
+  it("allow checking for existence of data", async () => {
+    const expectedKey = "hello";
+
+    await store.set(expectedKey, "");
+
+    assert.equal(await store.has(expectedKey), true);
+    assert.equal(await store.has("non-existing key"), false);
+  });
+
+  it("throw when unable to create a temp directory", async () => {
+    const mkdir = fs.promises.mkdir;
+    fs.promises.mkdir = () => {
+      throw new Error("Fake `fs.promises.mkdir` always throws");
+    };
+
+    try {
+      await store.set("hello", "world");
+      assert.fail();
+    } catch (err) {
+      fs.promises.mkdir = mkdir;
+    } finally {
+      fs.promises.mkdir = mkdir;
+    }
+  });
+});

--- a/src/store/__tests__/memory-store.test.ts
+++ b/src/store/__tests__/memory-store.test.ts
@@ -1,0 +1,28 @@
+import assert from "assert";
+import MemoryStore from "../memory-store";
+
+let store: MemoryStore;
+beforeEach(() => {
+  store = new MemoryStore();
+});
+
+describe("memory store should", () => {
+  it("allow retrieving data", async () => {
+    const expectedKey = "hello";
+    const expectedData = "world";
+
+    await store.set(expectedKey, expectedData);
+
+    assert.equal(await store.get(expectedKey), expectedData);
+    assert.equal(await store.get("non-existing key"), undefined);
+  });
+
+  it("allow checking for existence of data", async () => {
+    const expectedKey = "hello";
+
+    await store.set(expectedKey, "");
+
+    assert.equal(await store.has(expectedKey), true);
+    assert.equal(await store.has("non-existing key"), false);
+  });
+});

--- a/src/store/file-store.ts
+++ b/src/store/file-store.ts
@@ -12,8 +12,8 @@ export default class FileStore implements BuildStore {
     this._cache = new Map();
   }
   async _getKeyPath(key: string) {
-    const temp = await (this._temp ??= getTempDir(this._id));
-    return path.join(temp, key);
+    this._temp ??= getTempDir(this._id);
+    return path.join(await this._temp, key);
   }
   async has(key: string) {
     if (!this._cache.has(key)) {

--- a/src/store/file-store.ts
+++ b/src/store/file-store.ts
@@ -1,0 +1,63 @@
+import path from "path";
+import fs from "fs";
+import os from "os";
+import type { BuildStore } from "./types";
+
+export default class FileStore implements BuildStore {
+  _id: string;
+  _temp: Promise<string> | undefined;
+  _cache: Map<string, string>;
+  constructor(id: string) {
+    this._id = id;
+    this._cache = new Map();
+  }
+  async _getKeyPath(key: string) {
+    const temp = await (this._temp ??= getTempDir(this._id));
+    return path.join(temp, key);
+  }
+  async has(key: string) {
+    if (!this._cache.has(key)) {
+      const path = await this._getKeyPath(key);
+      try {
+        await fs.promises.access(path);
+      } catch (e) {
+        return false;
+      }
+    }
+    return true;
+  }
+  async get(key: string) {
+    let value = this._cache.get(key);
+    if (value === undefined) {
+      const path = await this._getKeyPath(key);
+      try {
+        value = await fs.promises.readFile(path, "utf-8");
+      } catch (e) {
+        return undefined;
+      }
+      this._cache.set(key, value);
+    }
+    return value;
+  }
+  async set(key: string, value: string) {
+    this._cache.set(key, value);
+    const path = await this._getKeyPath(key);
+    await fs.promises.writeFile(path, value, "utf-8");
+  }
+}
+
+async function getTempDir(id: string) {
+  const dir = path.join(os.tmpdir(), id);
+
+  try {
+    const stat = await fs.promises.stat(dir);
+    if (stat.isDirectory()) {
+      return dir;
+    }
+  } catch {
+    await fs.promises.mkdir(dir);
+    return dir;
+  }
+
+  throw new Error("Unable to create temp directory");
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,3 @@
+export { default as FileStore } from "./file-store";
+export { default as MemoryStore } from "./memory-store";
+export type { BuildStore } from "./types";

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -1,0 +1,17 @@
+import type { BuildStore } from "./types";
+
+export default class MemoryStore implements BuildStore {
+  _store: Map<string, string>;
+  constructor() {
+    this._store = new Map();
+  }
+  async has(key: string) {
+    return Promise.resolve(this._store.has(key));
+  }
+  async get(key: string) {
+    return Promise.resolve(this._store.get(key));
+  }
+  async set(key: string, value: string) {
+    this._store.set(key, value);
+  }
+}

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,0 +1,5 @@
+export interface BuildStore {
+  has(key: string): Promise<boolean>;
+  get(key: string): Promise<string | undefined>;
+  set(key: string, value: string): Promise<void>;
+}


### PR DESCRIPTION
## Description

Adds `store` option which allow specifying a method to preserve data between SSR and client builds. Provides two implementations: file system (default) and in memory.

## Motivation and Context

Various data is produced during the SSR build which is necessary for the client build in linked mode. Today this is written to the file system. This PR decouples this logic into a store interface which can be implemented in any way. By default the store will continue to use the file system but an alternative in memory store is also provided which can improve performance when using Vite programatically.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
