### PR TITLE
fix: cjs imports from marko files in dev

### DIFF
--- a/.changeset/olive-panthers-deliver.md
+++ b/.changeset/olive-panthers-deliver.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+fix: handle cjs dependencies of .marko templates

--- a/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/build.expected.loading.0.html
+++ b/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/build.expected.loading.0.html
@@ -1,9 +1,12 @@
 <div
   id="implicit"
 >
-  <div
+  <button
+    class="btn btn--secondary"
+    data-ebayui=""
     id="clickable"
+    type="button"
   >
     Mounted: false Clicks: 0
-  </div>
+  </button>
 </div>

--- a/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/build.expected.loading.0.html
+++ b/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/build.expected.loading.0.html
@@ -1,0 +1,9 @@
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: false Clicks: 0
+  </div>
+</div>

--- a/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/build.expected.loading.1.html
+++ b/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/build.expected.loading.1.html
@@ -1,0 +1,9 @@
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: true Clicks: 0
+  </div>
+</div>

--- a/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/build.expected.loading.1.html
+++ b/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/build.expected.loading.1.html
@@ -1,9 +1,12 @@
 <div
   id="implicit"
 >
-  <div
+  <button
+    class="btn btn--secondary"
+    data-ebayui=""
     id="clickable"
+    type="button"
   >
     Mounted: true Clicks: 0
-  </div>
+  </button>
 </div>

--- a/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/build.expected.step-0.0.html
+++ b/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/build.expected.step-0.0.html
@@ -1,0 +1,9 @@
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: true Clicks: 1
+  </div>
+</div>

--- a/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/build.expected.step-0.0.html
+++ b/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/build.expected.step-0.0.html
@@ -1,9 +1,12 @@
 <div
   id="implicit"
 >
-  <div
+  <button
+    class="btn btn--secondary"
+    data-ebayui=""
     id="clickable"
+    type="button"
   >
     Mounted: true Clicks: 1
-  </div>
+  </button>
 </div>

--- a/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/dev.expected.loading.0.html
+++ b/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/dev.expected.loading.0.html
@@ -1,9 +1,12 @@
 <div
   id="implicit"
 >
-  <div
+  <button
+    class="btn btn--secondary"
+    data-ebayui=""
     id="clickable"
+    type="button"
   >
     Mounted: false Clicks: 0
-  </div>
+  </button>
 </div>

--- a/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/dev.expected.loading.0.html
+++ b/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/dev.expected.loading.0.html
@@ -1,0 +1,9 @@
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: false Clicks: 0
+  </div>
+</div>

--- a/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/dev.expected.loading.1.html
+++ b/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/dev.expected.loading.1.html
@@ -1,0 +1,9 @@
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: true Clicks: 0
+  </div>
+</div>

--- a/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/dev.expected.loading.1.html
+++ b/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/dev.expected.loading.1.html
@@ -1,9 +1,12 @@
 <div
   id="implicit"
 >
-  <div
+  <button
+    class="btn btn--secondary"
+    data-ebayui=""
     id="clickable"
+    type="button"
   >
     Mounted: true Clicks: 0
-  </div>
+  </button>
 </div>

--- a/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/dev.expected.step-0.0.html
+++ b/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/dev.expected.step-0.0.html
@@ -1,0 +1,9 @@
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: true Clicks: 1
+  </div>
+</div>

--- a/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/dev.expected.step-0.0.html
+++ b/src/__tests__/fixtures/isomorphic-commonjs/__snapshots__/dev.expected.step-0.0.html
@@ -1,9 +1,12 @@
 <div
   id="implicit"
 >
-  <div
+  <button
+    class="btn btn--secondary"
+    data-ebayui=""
     id="clickable"
+    type="button"
   >
     Mounted: true Clicks: 1
-  </div>
+  </button>
 </div>

--- a/src/__tests__/fixtures/isomorphic-commonjs/dev-server.js
+++ b/src/__tests__/fixtures/isomorphic-commonjs/dev-server.js
@@ -1,0 +1,34 @@
+// In dev we'll start a Vite dev server in middleware mode,
+// and forward requests to our http request handler.
+
+const { createServer } = require("vite");
+const { join } = require("path");
+const markoPlugin = require("../../..").default;
+
+module.exports = (async () => {
+  const devServer = await createServer({
+    root: __dirname,
+    appType: "custom",
+    logLevel: "silent",
+    plugins: [markoPlugin()],
+    optimizeDeps: { force: true },
+    server: {
+      middlewareMode: true,
+      watch: {
+        ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
+      },
+    },
+  });
+  return devServer.middlewares.use(async (req, res, next) => {
+    try {
+      const { handler } = await devServer.ssrLoadModule(
+        join(__dirname, "./src/index.js")
+      );
+      await handler(req, res, next);
+    } catch (err) {
+      console.log(err);
+      devServer.ssrFixStacktrace(err);
+      return next(err);
+    }
+  });
+})();

--- a/src/__tests__/fixtures/isomorphic-commonjs/node_modules/test-package/common/html-attributes/index.js
+++ b/src/__tests__/fixtures/isomorphic-commonjs/node_modules/test-package/common/html-attributes/index.js
@@ -1,0 +1,37 @@
+"use strict";exports.__esModule = true;exports.processHtmlAttributes = processHtmlAttributes;const skipAttributes = /^htmlAttributes|renderBody|a11y.*$/;
+const EMPTY_ARR = [];
+
+/**
+ * Convert camelCase to kebab-case
+ * @param {String} s
+ */
+function camelToKebab(s) {
+  return s.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+/**
+ * Create object of HTML attributes for pass-through to the DOM
+ * All fields in ignore will be skipped. This should generally match with the marko.json
+ * input fields so that duplicate/unwanted attributes will not be rendered
+ * @param {Object} input
+ * @param {Array} ignore
+ */
+function processHtmlAttributes(input, ignore) {if (ignore === void 0) {ignore = EMPTY_ARR;}
+  const attributes = {};
+  const htmlAttributes = input.htmlAttributes;
+
+  let obj = htmlAttributes || {};
+  if (htmlAttributes) {
+    obj = Object.assign({}, htmlAttributes);
+  }
+  Object.keys(input).forEach((key) => {
+    if (ignore.indexOf(key) === -1 && !skipAttributes.test(key) && !obj[key]) {
+      obj[key] = input[key];
+    }
+  });
+  Object.keys(obj).forEach((key) => {
+    attributes[camelToKebab(key)] = obj[key];
+  });
+
+  return attributes;
+}

--- a/src/__tests__/fixtures/isomorphic-commonjs/node_modules/test-package/components/test-button/component-browser.js
+++ b/src/__tests__/fixtures/isomorphic-commonjs/node_modules/test-package/components/test-button/component-browser.js
@@ -1,0 +1,10 @@
+"use strict";exports.__esModule = true;exports.default = void 0;function _getRequireWildcardCache(nodeInterop) {if (typeof WeakMap !== "function") return null;var cacheBabelInterop = new WeakMap();var cacheNodeInterop = new WeakMap();return (_getRequireWildcardCache = function (nodeInterop) {return nodeInterop ? cacheNodeInterop : cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj, nodeInterop) {if (!nodeInterop && obj && obj.__esModule) {return obj;}if (obj === null || typeof obj !== "object" && typeof obj !== "function") {return { default: obj };}var cache = _getRequireWildcardCache(nodeInterop);if (cache && cache.has(obj)) {return cache.get(obj);}var newObj = {};var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor;for (var key in obj) {if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) {var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null;if (desc && (desc.get || desc.set)) {Object.defineProperty(newObj, key, desc);} else {newObj[key] = obj[key];}}}newObj.default = obj;if (cache) {cache.set(obj, newObj);}return newObj;}var _default =
+
+{
+  handleClick(originalEvent) {
+    if (!this.input.disabled) {
+      this.emit('click', { originalEvent });
+    }
+  },
+
+};exports.default = _default;module.exports = exports.default;

--- a/src/__tests__/fixtures/isomorphic-commonjs/node_modules/test-package/components/test-button/index.marko
+++ b/src/__tests__/fixtures/isomorphic-commonjs/node_modules/test-package/components/test-button/index.marko
@@ -1,0 +1,94 @@
+import { processHtmlAttributes } from "../../common/html-attributes"
+
+static function toJSON() {
+    return {
+        disabled: this.disabled
+    };
+}
+
+static var ignoredAttributes = [
+    "a11yText",
+    "partiallyDisabled",
+    "priority",
+    "size",
+    "split",
+    "fluid",
+    "fixedHeight",
+    "truncate",
+    "transparent",
+    "bodyState",
+    "toJSON",
+    "variant",
+    "borderless"
+];
+
+static var validPriorities = [
+    'primary',
+    'secondary',
+    'tertiary',
+    'delete'
+];
+
+$ {
+    input.toJSON = toJSON;
+    var size = input.size === "large" ? "large" : null;
+    var priority = input.priority || "secondary";
+    if (input.borderless || input.variant === 'form') {
+        priority = 'none';
+    }
+    var baseClass = input.href ? "fake-btn" : "btn";
+    var sizeClass = size && baseClass + "--" + size;
+    var truncateClass =
+        input.truncate &&
+        (sizeClass ? sizeClass + "-truncated" : baseClass + "--truncated");
+    var transparentClass = input.transparent ? baseClass + "--transparent" : "";
+    var fixedHeightClass =
+        input.fixedHeight &&
+        (sizeClass ? sizeClass + "-fixed-height" : baseClass + "--fixed-height");
+    var variant = input.variant || 'standard';
+    var variantClass = variant !== 'standard' && `${baseClass}--${input.variant}`;
+    var tag = input.href ? "a" : "button";
+    var split = input.split || 'none';
+    var htmlAttributes = processHtmlAttributes(data, ignoredAttributes);
+}
+<${tag}
+    ...htmlAttributes
+    onClick("handleClick")
+    onKeydown("handleKeydown")
+    onFocus('handleFocus')
+    onBlur('handleBlur')
+    class=[
+        input.class,
+        baseClass,
+        input.fluid && `${baseClass}--fluid`,
+        truncateClass,
+        fixedHeightClass,
+        transparentClass,
+        variantClass,
+        !truncateClass && !fixedHeightClass && sizeClass,
+        split !== 'none' && `${baseClass}--split-${split}`,
+        input.borderless && `${baseClass}--borderless`,
+        (validPriorities.includes(priority) &&
+        `${baseClass}--${priority}`)
+    ]
+    data-ebayui=true
+    type=(tag === "button" && (input.type || "button"))
+    aria-disabled=((input.partiallyDisabled) && "true")
+    aria-label=(input.bodyState === "loading" ? (input.a11yText || "Loading...") : input.ariaLabel)
+    >
+    <if(input.bodyState === "loading")>
+        <span class="btn__cell">
+            loading...
+        </span>
+    </if>
+    <else-if(input.bodyState === "expand")>
+        <span class="btn__cell">
+            <span class="btn__text">
+                <${input.renderBody}/>
+            </span>
+        </span>
+    </else-if>
+    <else>
+        <${input.renderBody}/>
+    </else>
+</>

--- a/src/__tests__/fixtures/isomorphic-commonjs/node_modules/test-package/components/test-button/index.marko
+++ b/src/__tests__/fixtures/isomorphic-commonjs/node_modules/test-package/components/test-button/index.marko
@@ -1,5 +1,7 @@
 import { processHtmlAttributes } from "../../common/html-attributes"
 
+export const foo = 1;
+
 static function toJSON() {
     return {
         disabled: this.disabled

--- a/src/__tests__/fixtures/isomorphic-commonjs/node_modules/test-package/components/test-button/marko-tag.json
+++ b/src/__tests__/fixtures/isomorphic-commonjs/node_modules/test-package/components/test-button/marko-tag.json
@@ -1,0 +1,39 @@
+{
+  "attribute-groups": ["html-attributes"],
+  "@*": {
+    "type": "expression",
+    "targetProperty": null
+  },
+  "@html-attributes": "expression",
+  "@partially-disabled": "boolean",
+  "@priority": "string",
+  "@size": "size",
+  "@fluid": "boolean",
+  "@fixed-height": "boolean",
+  "@truncate": "boolean",
+  "@transparent": "boolean",
+  "@borderless": "boolean",
+  "@autofocus": "#html-autofocus",
+  "@disabled": "#html-disabled",
+  "@form": "#html-form",
+  "@formaction": "#html-formaction",
+  "@formenctype": "#html-formenctype",
+  "@formmethod": "#html-formmethod",
+  "@formnovalidate": "#html-formnovalidate",
+  "@formtarget": "#html-formtarget",
+  "@name": "#html-name",
+  "@type": "#html-type",
+  "@value": "#html-value",
+  "@download": "#html-download",
+  "@href": "#html-href",
+  "@media": "#html-media",
+  "@ping": "#html-ping",
+  "@referrerpolicy": "#html-referrerpolicy",
+  "@rel": "#html-rel",
+  "@a11y-text": "string",
+  "@body-state": {
+    "enum": ["none", "loading", "expand"]
+  },
+  "@target": "#html-target",
+  "@aria-disabled": "never"
+}

--- a/src/__tests__/fixtures/isomorphic-commonjs/node_modules/test-package/marko.json
+++ b/src/__tests__/fixtures/isomorphic-commonjs/node_modules/test-package/marko.json
@@ -1,0 +1,3 @@
+{
+  "tags-dir": "./components"
+}

--- a/src/__tests__/fixtures/isomorphic-commonjs/node_modules/test-package/package.json
+++ b/src/__tests__/fixtures/isomorphic-commonjs/node_modules/test-package/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "test-package"
+}

--- a/src/__tests__/fixtures/isomorphic-commonjs/node_modules/test-package/test-button.browser.json
+++ b/src/__tests__/fixtures/isomorphic-commonjs/node_modules/test-package/test-button.browser.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": [
+        "./components/button"
+    ]
+}

--- a/src/__tests__/fixtures/isomorphic-commonjs/package.json
+++ b/src/__tests__/fixtures/isomorphic-commonjs/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "isomorphic-commonjs",
+  "dependencies": {
+    "test-package": "0.0.0"
+  }
+}

--- a/src/__tests__/fixtures/isomorphic-commonjs/server.js
+++ b/src/__tests__/fixtures/isomorphic-commonjs/server.js
@@ -1,0 +1,11 @@
+// In production, simply start up the http server.
+const path = require("path");
+const { createServer } = require("http");
+const serve = require("serve-handler");
+const { handler } = require("./dist/index.mjs");
+const serveOpts = { public: path.resolve(__dirname, "dist") };
+module.exports = createServer(async (req, res) => {
+  await handler(req, res);
+  if (res.headersSent) return;
+  await serve(req, res, serveOpts);
+});

--- a/src/__tests__/fixtures/isomorphic-commonjs/src/components/class-component.marko
+++ b/src/__tests__/fixtures/isomorphic-commonjs/src/components/class-component.marko
@@ -1,0 +1,20 @@
+class {
+  onCreate() {
+    this.state = {
+      clickCount: 0,
+      mounted: false
+    };
+  }
+  onMount() {
+    this.state.mounted = true;
+  }
+
+  handleClick() {
+    this.state.clickCount++;
+  }
+}
+
+<test-button#clickable on-click("handleClick")>
+  Mounted: ${state.mounted}
+  Clicks: ${state.clickCount}
+</test-button>

--- a/src/__tests__/fixtures/isomorphic-commonjs/src/components/implicit-component.marko
+++ b/src/__tests__/fixtures/isomorphic-commonjs/src/components/implicit-component.marko
@@ -1,0 +1,9 @@
+static {
+  if (typeof window === "object") {
+    document.body.firstElementChild.append("Loaded Implicit Component");
+  }
+}
+
+<div#implicit>
+  <class-component/>
+</div>

--- a/src/__tests__/fixtures/isomorphic-commonjs/src/components/layout-component.marko
+++ b/src/__tests__/fixtures/isomorphic-commonjs/src/components/layout-component.marko
@@ -1,0 +1,15 @@
+static {
+  if (typeof window === "object") {
+    document.body.firstElementChild.append("Loaded Layout Component");
+  }
+}
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Hello World</title>
+</head>
+<body>
+  <${input.renderBody}/>
+</body>
+</html>

--- a/src/__tests__/fixtures/isomorphic-commonjs/src/index.js
+++ b/src/__tests__/fixtures/isomorphic-commonjs/src/index.js
@@ -1,0 +1,9 @@
+import template from "./template.marko";
+
+export function handler(req, res) {
+  if (req.url === "/") {
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    template.render({}, res);
+  }
+}

--- a/src/__tests__/fixtures/isomorphic-commonjs/src/template.marko
+++ b/src/__tests__/fixtures/isomorphic-commonjs/src/template.marko
@@ -1,0 +1,9 @@
+style {
+  div { color: green }
+}
+
+<layout-component>
+  <div#app>
+    <implicit-component/>
+  </div>
+</layout-component>

--- a/src/__tests__/fixtures/isomorphic-commonjs/test.config.ts
+++ b/src/__tests__/fixtures/isomorphic-commonjs/test.config.ts
@@ -1,0 +1,4 @@
+export const ssr = true;
+export async function steps() {
+  await page.click("#clickable");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,7 +230,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
                 ) {
                   optimizeTaglibDeps.push(relativePath);
                 } else {
-                  (cjsImports ??= new Map()).set(entry, {
+                  (cjsImports ??= new Map()).set(normalizePath(entry), {
                     template: tag.template,
                   });
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In dev mode, .marko files with CommonJS dependencies will fail in SSR because Vite loads them in ESM context.

This PR attempts to handle this case by wrapping them in module that requires it using `createRequire`. This causes the marko file to be loaded using Marko's require hook in a CommonJS context.
- The mechanism is only used in dev
- A heuristic is used to test if the module is likely CommonJS and only these files are wrapped

<!--- Describe your changes in detail.  Include the package name if applicable. -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [X] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
