### PR TITLE
fix: resolving assets from virtual files

### DIFF
--- a/.changeset/grumpy-books-add.md
+++ b/.changeset/grumpy-books-add.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Fix resolving files from virtual files (eg inline stylesheets).

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,9 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
     from,
     dep
   ) => {
-    const query = `${virtualFileQuery}&id=${normalizePath(dep.virtualPath)}`;
+    const query = `${virtualFileQuery}&id=${encodeURIComponent(
+      normalizePath(dep.virtualPath)
+    )}`;
     const normalizedFrom = normalizePath(from);
     const id = normalizePath(normalizedFrom) + query;
 


### PR DESCRIPTION
## Description

Our unique virtual file paths did not properly encode the virtual file. This led vite to incorrectly resolve relative references within virtual files (eg inline stylesheets).

Resolves #53

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
