### PR TITLE
fix: base path script in head or body when present

### DIFF
--- a/.changeset/wet-parents-occur.md
+++ b/.changeset/wet-parents-occur.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Ensure base path script is written in head or body when those elements are present

--- a/src/__tests__/fixtures/isomorphic-runtime-base-path/test.config.ts
+++ b/src/__tests__/fixtures/isomorphic-runtime-base-path/test.config.ts
@@ -1,7 +1,24 @@
 import type { Options } from "../../..";
+import assert from "assert";
+
+async function hasScript(pattern: RegExp) {
+  const headScripts = await page.locator("head > script");
+  const len = await headScripts.count();
+  for (let i = 0; i < len; i++) {
+    const script = await headScripts.nth(i).innerHTML();
+    if (pattern.test(script)) {
+      return true;
+    }
+  }
+  return false;
+}
 
 export const ssr = true;
 export async function steps() {
+  assert(
+    await hasScript(/\$mbp[a-z0-1-_\s]*=/i),
+    "Base path script not found in head"
+  );
   await page.click("#clickable");
 }
 export const options: Options = {

--- a/src/components/vite.marko
+++ b/src/components/vite.marko
@@ -7,6 +7,14 @@ static function renderAssets(slot) {
     const lastWrittenEntry = this[slotWrittenEntriesKey] || 0;
     const writtenEntries = (this[slotWrittenEntriesKey] = entries.length);
 
+    if(this.___viteBasePath && !this.___flushedMBP && slot !== "head-prepend") {
+        this.___flushedMBP = true;
+
+        html += `<script${this.___viteInjectAttrs}>${
+          this.___viteBaseVar
+        }=${JSON.stringify(this.___viteBasePath)}</script>`
+    }
+
     for (let i = lastWrittenEntry; i < writtenEntries; i++) {
       let entry = entries[i];
 
@@ -62,11 +70,5 @@ $ if (!out.global.___viteRenderAssets) {
 }
 
 <__flush_here_and_after__>
-  <if(input.base && !out.global.___flushedMBP)>
-    $ out.global.___flushedMBP = true;
-    $!{`<script${out.global.___viteInjectAttrs}>${
-      out.global.___viteBaseVar
-    }=${JSON.stringify(input.base)}</script>`}
-  </if>
   $!{out.global.___viteRenderAssets(input.slot)}
 </__flush_here_and_after__>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The script which sets the optional runtime base path for resources was being rendered before the doctype declaration. This change ensures the script is rendered right before the JS asset scripts are written.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
