### PR TITLE
fix: ensure proper resolve condition set for vitest env

### DIFF
--- a/.changeset/pretty-plums-perform.md
+++ b/.changeset/pretty-plums-perform.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Fix support for using this plugin with Vitest and a browser environment.

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,6 +223,16 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
 
         if (isTest) {
           linked = false;
+
+          if (
+            ((config as any).test?.environment as string | undefined)?.includes(
+              "dom"
+            )
+          ) {
+            config.resolve ??= {};
+            config.resolve.conditions ??= [];
+            config.resolve.conditions.push("browser");
+          }
         }
 
         if (linked && !registeredTag) {


### PR DESCRIPTION
## Description

Ensure `browser` export condition is configured when in `test` mode and targeting a dom environment.

## Motivation and Context

Workaround for https://github.com/vitest-dev/vitest/issues/2603 which causes the incorrect Marko runtime to be loaded in the brower env for that test runner.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
