### PR TITLE
fix: ssr bundled Marko files in build mode

### DIFF
--- a/.changeset/fair-peas-impress.md
+++ b/.changeset/fair-peas-impress.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Fix regression which prevented SSR cjs Marko files from being properly bundled.

--- a/src/index.ts
+++ b/src/index.ts
@@ -534,6 +534,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
 
           if (!query) {
             if (
+              !isBuild &&
               /[\\/]node_modules[\\/]/.test(id) &&
               getModuleType(id) === "cjs"
             ) {


### PR DESCRIPTION
## Description

Fixes a regression where SSR Marko files were not being bundled in `build` mode.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
