### PR TITLE
test: change server type for vite 5 change

### DIFF
--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -11,6 +11,7 @@ import { createRequire } from "module";
 import * as playwright from "playwright";
 import { defaultNormalizer, defaultSerializer } from "@marko/fixture-snapshots";
 import markoPlugin, { type Options } from "..";
+import type { Http2SecureServer } from "http2";
 
 // https://github.com/esbuild-kit/tsx/issues/113
 const { toString } = Function.prototype;
@@ -202,7 +203,11 @@ for (const fixture of fs.readdirSync(FIXTURES)) {
   });
 }
 
-async function testPage(dir: string, steps: Step[], server: http.Server) {
+async function testPage(
+  dir: string,
+  steps: Step[],
+  server: http.Server | Http2SecureServer
+) {
   try {
     if (!server.listening) await once(server, "listening");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make `testPage` function to accept `http.Server | Http2SecureServer` instead of `http.Server`.

## Motivation and Context
This PR fixes the type incompatibility with Vite 5.

related: https://github.com/vitejs/vite/pull/14834

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
