### PR TITLE
feat: relative assets transform

### DIFF
--- a/.changeset/sharp-guests-know.md
+++ b/.changeset/sharp-guests-know.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": minor
+---
+
+Support inline relative asset paths from native tags.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ export default defineConfig({
 });
 ```
 
+# Browser asset references
+
+With @marko/vite when a _static relative path_ is used for certain native tag attributes, the relative asset will be imported and processed by Vite.
+
+As an example, with the following template, the `logo.svg` will be imported and processed as if it was a `import` at the root of the file.
+
+```
+<img src="./logo.svg">
+
+// Would produce a Vite processed asset and update the src, eg with the following output
+<img src="/assets/logo-TwEWmgMb.svg">
+```
+
+You can see the list of elements and their attributes which are processed [here](./src/relative-assets-transform.ts).
+
 # Linked Mode
 
 By default this plugin operates in `linked` mode (you can disabled this by passing [`linked: false` as an option](#options.linked)). In `linked` mode the plugin automatically discovers all of the entry `.marko` files while compiling the server, and tells `Vite` which modules to load in the browser.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/babel__core": "^7.20.4",
         "@types/jsdom": "^21.1.5",
         "@types/mocha": "^10.0.4",
-        "@types/node": "^20.9.0",
+        "@types/node": "^20.9.1",
         "@types/resolve": "^1.20.5",
         "@types/serve-handler": "^6.1.4",
         "@typescript-eslint/eslint-plugin": "^6.11.0",
@@ -42,12 +42,12 @@
         "mocha": "^10.2.0",
         "mocha-snap": "^5.0.0",
         "nyc": "^15.1.0",
-        "playwright": "^1.39.0",
+        "playwright": "^1.40.0",
         "prettier": "^3.1.0",
         "serve-handler": "^6.1.5",
         "tsx": "^4.1.2",
         "typescript": "^5.2.2",
-        "vite": "^5.0.0-beta.17"
+        "vite": "^5.0.0"
       },
       "peerDependencies": {
         "@marko/compiler": "^5",
@@ -1981,9 +1981,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
-      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
+      "version": "20.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.1.tgz",
+      "integrity": "sha512-HhmzZh5LSJNS5O8jQKpJ/3ZcrrlG6L70hpGqMIAoM9YVD0YBRNWYsfwcXq8VnSjlNpCpgLzMXdiPo+dxcvSmiA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -3470,9 +3470,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.582",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.582.tgz",
-      "integrity": "sha512-89o0MGoocwYbzqUUjc+VNpeOFSOK9nIdC5wY4N+PVUarUK0MtjyTjks75AZS2bW4Kl8MdewdFsWaH0jLy+JNoA==",
+      "version": "1.4.586",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.586.tgz",
+      "integrity": "sha512-qMa+E6yf1fNQbg3G66pHLXeJUP5CCCzNat1VPczOZOqgI2w4u+8y9sQnswMdGs5m4C1rOePq37EVBr/nsPQY7w==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -4955,9 +4955,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -7221,12 +7221,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
-      "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.0.tgz",
+      "integrity": "sha512-gyHAgQjiDf1m34Xpwzaqb76KgfzYrhK7iih+2IzcOCoZWr/8ZqmdBw+t0RU85ZmfJMgtgAiNtBQ/KS2325INXw==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.39.0"
+        "playwright-core": "1.40.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -7239,9 +7239,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
-      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.0.tgz",
+      "integrity": "sha512-fvKewVJpGeca8t0ipM56jkVSU6Eo0RmFvQ/MaCQNDYm+sdvKkMBBWTE1FdeMqIdumRaXXjZChWHvIzCGM/tA/Q==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
@@ -9677,9 +9677,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.0.0-beta.19",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.0-beta.19.tgz",
-      "integrity": "sha512-Huoj7XUlkhSLHhIOf4FgDrxmHJMKgfvG9ocB4kJmTKSeWfLgHIQ86xYC8+eA/RBxFo9zRQXX81VUgW8l7Wri3Q==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.0.tgz",
+      "integrity": "sha512-ESJVM59mdyGpsiNAeHQOR/0fqNoOyWPYesFto8FFZugfmhdHx8Fzd8sF3Q/xkVhZsyOxHfdM7ieiVAorI9RjFw==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@types/babel__core": "^7.20.4",
     "@types/jsdom": "^21.1.5",
     "@types/mocha": "^10.0.4",
-    "@types/node": "^20.9.0",
+    "@types/node": "^20.9.1",
     "@types/resolve": "^1.20.5",
     "@types/serve-handler": "^6.1.4",
     "@typescript-eslint/eslint-plugin": "^6.11.0",
@@ -38,12 +38,12 @@
     "mocha": "^10.2.0",
     "mocha-snap": "^5.0.0",
     "nyc": "^15.1.0",
-    "playwright": "^1.39.0",
+    "playwright": "^1.40.0",
     "prettier": "^3.1.0",
     "serve-handler": "^6.1.5",
     "tsx": "^4.1.2",
     "typescript": "^5.2.2",
-    "vite": "^5.0.0-beta.17"
+    "vite": "^5.0.0"
   },
   "files": [
     "dist",

--- a/src/__tests__/fixtures/isomorphic-relative-asset-import/__snapshots__/build.expected.loading.0.html
+++ b/src/__tests__/fixtures/isomorphic-relative-asset-import/__snapshots__/build.expected.loading.0.html
@@ -1,0 +1,13 @@
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: false Clicks: 0
+    <img
+      alt="logo"
+      src="/assets/logo-[hash].svg"
+    />
+  </div>
+</div>

--- a/src/__tests__/fixtures/isomorphic-relative-asset-import/__snapshots__/build.expected.loading.1.html
+++ b/src/__tests__/fixtures/isomorphic-relative-asset-import/__snapshots__/build.expected.loading.1.html
@@ -1,0 +1,13 @@
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: true Clicks: 0
+    <img
+      alt="logo"
+      src="/assets/logo-[hash].svg"
+    />
+  </div>
+</div>

--- a/src/__tests__/fixtures/isomorphic-relative-asset-import/__snapshots__/build.expected.step-0.0.html
+++ b/src/__tests__/fixtures/isomorphic-relative-asset-import/__snapshots__/build.expected.step-0.0.html
@@ -1,0 +1,13 @@
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: true Clicks: 1
+    <img
+      alt="logo"
+      src="/assets/logo-[hash].svg"
+    />
+  </div>
+</div>

--- a/src/__tests__/fixtures/isomorphic-relative-asset-import/__snapshots__/dev.expected.loading.0.html
+++ b/src/__tests__/fixtures/isomorphic-relative-asset-import/__snapshots__/dev.expected.loading.0.html
@@ -1,0 +1,13 @@
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: false Clicks: 0
+    <img
+      alt="logo"
+      src="/src/components/logo.svg"
+    />
+  </div>
+</div>

--- a/src/__tests__/fixtures/isomorphic-relative-asset-import/__snapshots__/dev.expected.loading.1.html
+++ b/src/__tests__/fixtures/isomorphic-relative-asset-import/__snapshots__/dev.expected.loading.1.html
@@ -1,0 +1,13 @@
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: true Clicks: 0
+    <img
+      alt="logo"
+      src="/src/components/logo.svg"
+    />
+  </div>
+</div>

--- a/src/__tests__/fixtures/isomorphic-relative-asset-import/__snapshots__/dev.expected.step-0.0.html
+++ b/src/__tests__/fixtures/isomorphic-relative-asset-import/__snapshots__/dev.expected.step-0.0.html
@@ -1,0 +1,13 @@
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: true Clicks: 1
+    <img
+      alt="logo"
+      src="/src/components/logo.svg"
+    />
+  </div>
+</div>

--- a/src/__tests__/fixtures/isomorphic-relative-asset-import/dev-server.mjs
+++ b/src/__tests__/fixtures/isomorphic-relative-asset-import/dev-server.mjs
@@ -1,0 +1,38 @@
+// In dev we'll start a Vite dev server in middleware mode,
+// and forward requests to our http request handler.
+
+import { createServer } from "vite";
+import path from "path";
+import url from "url";
+import { createRequire } from "module";
+
+// change to import once marko-vite is updated to ESM
+const markoPlugin = createRequire(import.meta.url)("../../..").default;
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+const devServer = await createServer({
+  root: __dirname,
+  appType: "custom",
+  logLevel: "silent",
+  plugins: [markoPlugin()],
+  optimizeDeps: { force: true },
+  server: {
+    middlewareMode: true,
+    watch: {
+      ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
+    },
+  },
+});
+
+export default devServer.middlewares.use(async (req, res, next) => {
+  try {
+    const { handler } = await devServer.ssrLoadModule(
+      path.join(__dirname, "./src/index.js")
+    );
+    await handler(req, res, next);
+  } catch (err) {
+    devServer.ssrFixStacktrace(err);
+    return next(err);
+  }
+});

--- a/src/__tests__/fixtures/isomorphic-relative-asset-import/server.mjs
+++ b/src/__tests__/fixtures/isomorphic-relative-asset-import/server.mjs
@@ -1,0 +1,18 @@
+// In production, simply start up the http server.
+import path from 'path'
+import url from 'url';
+import { createServer } from "http";
+import serve from "serve-handler";
+
+globalThis.assetsPath = "/my-prefix/";
+// dyanmic import so globalThis.assetsPath can be set prior to the imported code executing
+const { handler } = await import("./dist/index.mjs"); 
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const serveOpts = { public: path.resolve(__dirname, "dist") };
+
+export default createServer(async (req, res) => {
+  await handler(req, res);
+  if (res.headersSent) return;
+  await serve(req, res, serveOpts);
+});

--- a/src/__tests__/fixtures/isomorphic-relative-asset-import/src/components/class-component.marko
+++ b/src/__tests__/fixtures/isomorphic-relative-asset-import/src/components/class-component.marko
@@ -1,5 +1,3 @@
-import logo from "./logo.svg";
-
 class {
   onCreate() {
     this.state = {
@@ -20,6 +18,5 @@ class {
   Mounted: ${state.mounted}
   Clicks: ${state.clickCount}
 
-  LOGO_PATH: ${logo}
-  ENV: ${import.meta.env.BASE_URL}
+  <img src="./logo.svg" alt="logo">
 </div>

--- a/src/__tests__/fixtures/isomorphic-relative-asset-import/src/components/implicit-component.marko
+++ b/src/__tests__/fixtures/isomorphic-relative-asset-import/src/components/implicit-component.marko
@@ -1,0 +1,9 @@
+static {
+  if (typeof window === "object") {
+    document.body.firstElementChild.append("Loaded Implicit Component");
+  }
+}
+
+<div#implicit>
+  <class-component/>
+</div>

--- a/src/__tests__/fixtures/isomorphic-relative-asset-import/src/components/layout-component.marko
+++ b/src/__tests__/fixtures/isomorphic-relative-asset-import/src/components/layout-component.marko
@@ -1,0 +1,15 @@
+static {
+  if (typeof window === "object") {
+    document.body.firstElementChild.append("Loaded Layout Component");
+  }
+}
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Hello World</title>
+</head>
+<body>
+  <${input.renderBody}/>
+</body>
+</html>

--- a/src/__tests__/fixtures/isomorphic-relative-asset-import/src/components/logo.svg
+++ b/src/__tests__/fixtures/isomorphic-relative-asset-import/src/components/logo.svg
@@ -1,0 +1,72 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="512"
+  viewBox="0 0 2560 1400"
+>
+  <style>
+    stop:not([stop-color]) {
+      stop-color: inherit;
+    }
+  </style>
+  <g>
+    <path fill="url(#h)" d="M2132 0h-361l427 697-428 697h361l428-697z" />
+    <linearGradient id="h" x2="0" y2="1" stop-color="#df1b1c">
+      <stop offset="0" stop-color="#e02a89" />
+      <stop offset=".31" />
+      <stop offset=".5" />
+      <stop offset=".5" stop-color="#7f1e4f" />
+      <stop offset=".833" />
+    </linearGradient>
+  </g>
+  <g>
+    <g>
+      <path fill="url(#a)" d="M427 0h361L361 697l427 697H427L0 698z" />
+      <linearGradient id="a" x2="0" y2="1" stop-color="#44bfef">
+        <stop offset="0" stop-color="#00828b" />
+        <stop offset=".25" />
+        <stop offset=".5" stop-color="#88d0f1" />
+        <stop offset=".5" />
+        <stop offset=".685" />
+        <stop offset="1" stop-color="#2073ba" />
+      </linearGradient>
+    </g>
+    <g>
+      <path fill="url(#b)" d="M854 697h361L788 0H427z" />
+      <linearGradient id="b" x2="0" y2="1">
+        <stop offset="0" stop-color="#8ed0e1" />
+        <stop offset="1" stop-color="#00ac71" />
+      </linearGradient>
+      <path fill="url(#c)" d="M607 294L788 0H427z" />
+      <linearGradient id="c" x2="0" y2="1" stop-color="#419aaa">
+        <stop offset="0" stop-opacity="0" />
+        <stop offset="1" />
+      </linearGradient>
+    </g>
+    <g>
+      <path fill="url(#d)" d="M1281 0h361l-427 697H854z" />
+      <linearGradient id="d" x2="0" y2="1">
+        <stop offset="0" stop-color="#698932" />
+        <stop offset="0.833" stop-color="#8dc220" />
+      </linearGradient>
+      <path fill="url(#e)" d="M1034 402L854 698H1216z" />
+      <linearGradient id="e" x2="0" y2="1" stop-color="#67b168">
+        <stop offset="0" />
+        <stop offset="1" stop-opacity="0" />
+      </linearGradient>
+    </g>
+    <g>
+      <path fill="url(#f)" d="M1642 0h-361l428 697-428 697h361l428-697z" />
+      <linearGradient id="f" x2="0" y2="1" stop-color="#f9bc00">
+        <stop offset="0" stop-color="#ffed01" />
+        <stop offset=".5" />
+        <stop offset=".5" stop-color="#e95506" />
+        <stop offset=".833" />
+      </linearGradient>
+      <path fill="url(#g)" d="M1281 0H1642 L1461 294z" />
+      <linearGradient id="g" x2="0" y2="1" stop-color="#b5c449">
+        <stop offset="0" stop-opacity="0" />
+        <stop offset="1" />
+      </linearGradient>
+    </g>
+  </g>
+</svg>

--- a/src/__tests__/fixtures/isomorphic-relative-asset-import/src/index.js
+++ b/src/__tests__/fixtures/isomorphic-relative-asset-import/src/index.js
@@ -1,0 +1,9 @@
+import template from "./template.marko";
+
+export function handler(req, res) {
+  if (req.url === "/") {
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    template.render({}, res);
+  }
+}

--- a/src/__tests__/fixtures/isomorphic-relative-asset-import/src/template.marko
+++ b/src/__tests__/fixtures/isomorphic-relative-asset-import/src/template.marko
@@ -1,0 +1,9 @@
+style {
+  div { color: green }
+}
+
+<layout-component>
+  <div#app>
+    <implicit-component/>
+  </div>
+</layout-component>

--- a/src/__tests__/fixtures/isomorphic-relative-asset-import/test.config.ts
+++ b/src/__tests__/fixtures/isomorphic-relative-asset-import/test.config.ts
@@ -1,0 +1,4 @@
+export const ssr = true;
+export async function steps() {
+  await page.click("#clickable");
+}

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -51,7 +51,7 @@ before(async () => {
     context.exposeFunction("__track__", (html: string) => {
       const formatted = defaultSerializer(
         defaultNormalizer(JSDOM.fragment(html)),
-      );
+      ).replace(/-[a-z0-9]+(\.\w+)/i, "-[hash]$1");
 
       if (changes.at(-1) !== formatted) {
         changes.push(formatted);

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
   renderAssetsRuntimeId,
 } from "./render-assets-runtime";
 import renderAssetsTransform from "./render-assets-transform";
+import relativeAssetsTransform from "./relative-assets-transform";
 import { ReadOncePersistedStore } from "./read-once-persisted-store";
 
 export namespace API {
@@ -258,6 +259,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
           compiler.taglib.register("@marko/vite", {
             "<head>": { transformer: renderAssetsTransform },
             "<body>": { transformer: renderAssetsTransform },
+            "<*>": { transformer: relativeAssetsTransform },
           });
         }
 

--- a/src/relative-assets-transform.ts
+++ b/src/relative-assets-transform.ts
@@ -1,0 +1,62 @@
+import type { types } from "@marko/compiler";
+const attrSrc = new Set(["src"]);
+const attrHref = new Set(["href"]);
+const assetAttrsByTag = new Map([
+  ["audio", attrSrc],
+  ["embed", attrSrc],
+  ["iframe", attrSrc],
+  ["img", new Set(["src", "srcset"])],
+  ["input", attrSrc],
+  ["source", attrSrc],
+  ["track", attrSrc],
+  ["video", new Set(["src", "poster"])],
+  ["a", attrHref],
+  ["area", attrHref],
+  ["link", attrHref],
+  ["object", new Set(["data"])],
+  ["body", new Set(["background"])],
+]);
+
+export default function transform(
+  tag: types.NodePath<types.MarkoTag>,
+  t: typeof types,
+) {
+  const { name, attributes } = tag.node;
+  if (name.type !== "StringLiteral") {
+    return;
+  }
+
+  const assetAttrs = assetAttrsByTag.get(name.value);
+  if (!assetAttrs) {
+    return;
+  }
+
+  for (const attr of attributes) {
+    if (
+      attr.type === "MarkoAttribute" &&
+      attr.value.type === "StringLiteral" &&
+      assetAttrs.has(attr.name)
+    ) {
+      const { value } = attr.value;
+      if (
+        !(
+          (
+            value[0] === "/" || // Ignore absolute paths.
+            !/\.[^.]+$/.test(value) || // Ignore paths without a file extension.
+            /^[a-z]{2,}:/i.test(value)
+          ) // Ignore paths with a protocol.
+        )
+      ) {
+        const importedId = tag.scope.generateUid(value);
+        attr.value = t.identifier(importedId);
+        tag.hub.file.path.unshiftContainer(
+          "body",
+          t.importDeclaration(
+            [t.importDefaultSpecifier(t.identifier(importedId))],
+            t.stringLiteral(value),
+          ),
+        );
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Brings over the (adapted) native tag relative asset import transform from @marko/run.
This allows you to have code like `<img src="./relative-path.png">` be processed with vite.
