### PR TITLE
fix: improve resolve alias with ~

### DIFF
--- a/.changeset/rude-roses-draw.md
+++ b/.changeset/rude-roses-draw.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Update ~ resolve alias to avoid matching ~ by itself as the package name.

--- a/src/index.ts
+++ b/src/index.ts
@@ -361,7 +361,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
           resolve: {
             alias: [
               {
-                find: /^~/,
+                find: /^~(?!\/)/,
                 replacement: "",
               },
             ],


### PR DESCRIPTION
## Description

Avoids matching `~/` with our resolve alias.
Somewhat of a workaround for #133.
