### PR TITLE
fix: native addons failure in stackblitz

### DIFF
--- a/.changeset/soft-fireants-burn.md
+++ b/.changeset/soft-fireants-burn.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Load cjs transform code conditionally on-demand for envs that don't support native addons


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Stackblitz Web Containers do not support loading native addons. Our CJS to ESM transform code relies on `@parcel/source-maps` which loads native addons. This change makes loading this package conditional and on-demand to prevent runtime failures when CJS transformations are not needed.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
