### PR TITLE
fix: broken vite preload when used with cspnonce

### DIFF
--- a/.changeset/silent-sheep-admire.md
+++ b/.changeset/silent-sheep-admire.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Fix issue in dev mode where Content Security Policies may prevent script from running

--- a/src/render-assets-runtime.ts
+++ b/src/render-assets-runtime.ts
@@ -64,7 +64,7 @@ function renderAssets(slot) {
           html += "document.documentElement.style.visibility='';";
           html +=
             "if(document.documentElement.getAttribute('style')==='')document.documentElement.removeAttribute('style');";
-          html += "</script><script class=marko-vite-preload>document.documentElement.style.visibility='hidden'</script>";
+          html += \`</script><script class=marko-vite-preload\${this.___viteInjectAttrs}>document.documentElement.style.visibility='hidden'</script>\`;
         }
       }`
       }


### PR DESCRIPTION
Fix a bug since @marko/vite@4.1.14, whereby Content-Security-Policies errors are thrown when `$global.cspNonce` is used.