### PR TITLE
chore: set `build.assetsInlineLimit: 0` for SSR tests in dev

### DIFF
--- a/src/__tests__/fixtures/isomorphic-base-url/dev-server.mjs
+++ b/src/__tests__/fixtures/isomorphic-base-url/dev-server.mjs
@@ -23,6 +23,9 @@ const devServer = await createServer({
       ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
     },
   },
+  build: {
+    assetsInlineLimit: 0,
+  },
 });
 
 export default devServer.middlewares.use(async (req, res, next) => {

--- a/src/__tests__/fixtures/isomorphic-basic/dev-server.mjs
+++ b/src/__tests__/fixtures/isomorphic-basic/dev-server.mjs
@@ -23,6 +23,9 @@ const devServer = await createServer({
       ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
     },
   },
+  build: {
+    assetsInlineLimit: 0,
+  },
 });
 
 export default devServer.middlewares.use(async (req, res, next) => {

--- a/src/__tests__/fixtures/isomorphic-bundle-splitting/dev-server.mjs
+++ b/src/__tests__/fixtures/isomorphic-bundle-splitting/dev-server.mjs
@@ -23,6 +23,9 @@ const devServer = await createServer({
       ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
     },
   },
+  build: {
+    assetsInlineLimit: 0,
+  },
 });
 
 export default devServer.middlewares.use(async (req, res, next) => {

--- a/src/__tests__/fixtures/isomorphic-circular-entry-file/dev-server.mjs
+++ b/src/__tests__/fixtures/isomorphic-circular-entry-file/dev-server.mjs
@@ -23,6 +23,9 @@ const devServer = await createServer({
       ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
     },
   },
+  build: {
+    assetsInlineLimit: 0,
+  },
 });
 
 export default devServer.middlewares.use(async (req, res, next) => {

--- a/src/__tests__/fixtures/isomorphic-commonjs-dir-import/dev-server.mjs
+++ b/src/__tests__/fixtures/isomorphic-commonjs-dir-import/dev-server.mjs
@@ -23,6 +23,9 @@ const devServer = await createServer({
       ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
     },
   },
+  build: {
+    assetsInlineLimit: 0,
+  },
 });
 
 export default devServer.middlewares.use(async (req, res, next) => {

--- a/src/__tests__/fixtures/isomorphic-commonjs-svg/dev-server.mjs
+++ b/src/__tests__/fixtures/isomorphic-commonjs-svg/dev-server.mjs
@@ -23,6 +23,9 @@ const devServer = await createServer({
       ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
     },
   },
+  build: {
+    assetsInlineLimit: 0,
+  },
 });
 
 export default devServer.middlewares.use(async (req, res, next) => {

--- a/src/__tests__/fixtures/isomorphic-commonjs/dev-server.mjs
+++ b/src/__tests__/fixtures/isomorphic-commonjs/dev-server.mjs
@@ -23,6 +23,9 @@ const devServer = await createServer({
       ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
     },
   },
+  build: {
+    assetsInlineLimit: 0,
+  },
 });
 
 export default devServer.middlewares.use(async (req, res, next) => {

--- a/src/__tests__/fixtures/isomorphic-css-loader-import/dev-server.mjs
+++ b/src/__tests__/fixtures/isomorphic-css-loader-import/dev-server.mjs
@@ -23,6 +23,9 @@ const devServer = await createServer({
       ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
     },
   },
+  build: {
+    assetsInlineLimit: 0,
+  },
 });
 
 export default devServer.middlewares.use(async (req, res, next) => {

--- a/src/__tests__/fixtures/isomorphic-glob-import/dev-server.mjs
+++ b/src/__tests__/fixtures/isomorphic-glob-import/dev-server.mjs
@@ -23,6 +23,9 @@ const devServer = await createServer({
       ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
     },
   },
+  build: {
+    assetsInlineLimit: 0,
+  },
 });
 
 export default devServer.middlewares.use(async (req, res, next) => {

--- a/src/__tests__/fixtures/isomorphic-marko-dep/dev-server.mjs
+++ b/src/__tests__/fixtures/isomorphic-marko-dep/dev-server.mjs
@@ -23,6 +23,9 @@ const devServer = await createServer({
       ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
     },
   },
+  build: {
+    assetsInlineLimit: 0,
+  },
 });
 
 export default devServer.middlewares.use(async (req, res, next) => {

--- a/src/__tests__/fixtures/isomorphic-modulepreload/dev-server.mjs
+++ b/src/__tests__/fixtures/isomorphic-modulepreload/dev-server.mjs
@@ -23,6 +23,9 @@ const devServer = await createServer({
       ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
     },
   },
+  build: {
+    assetsInlineLimit: 0,
+  },
 });
 
 export default devServer.middlewares.use(async (req, res, next) => {

--- a/src/__tests__/fixtures/isomorphic-relative-asset-import/dev-server.mjs
+++ b/src/__tests__/fixtures/isomorphic-relative-asset-import/dev-server.mjs
@@ -23,6 +23,9 @@ const devServer = await createServer({
       ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
     },
   },
+  build: {
+    assetsInlineLimit: 0,
+  },
 });
 
 export default devServer.middlewares.use(async (req, res, next) => {

--- a/src/__tests__/fixtures/isomorphic-runtime-base-path/dev-server.mjs
+++ b/src/__tests__/fixtures/isomorphic-runtime-base-path/dev-server.mjs
@@ -23,6 +23,9 @@ const devServer = await createServer({
       ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
     },
   },
+  build: {
+    assetsInlineLimit: 0,
+  },
 });
 
 export default devServer.middlewares.use(async (req, res, next) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes ecosystem-ci with Vite v6 beta by setting `build.assetsInlineLimit: 0` for SSR tests in dev.

<!--- Describe your changes in detail.  Include the package name if applicable. -->

## Motivation and Context

Vite 6 now inlines SVG files even in dev that will be inlined for build (https://github.com/vitejs/vite/pull/18581).
That caused the snapshot to change and made the ecosystem-ci to fail.
Because `build.assetsInlineLimit: 0` was set for SSR test in build, I set them in dev as well to make the ecosystem-ci pass.

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
