### PR TITLE
Fix incorrectly resolved ids

### DIFF
--- a/.changeset/silver-owls-sneeze.md
+++ b/.changeset/silver-owls-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Fix issue where query is improperly appended to resolved id containing version query

--- a/src/index.ts
+++ b/src/index.ts
@@ -545,7 +545,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
               : await this.resolve(importee, importer, resolveOpts);
 
           if (resolved) {
-            resolved.id += importeeQuery;
+            resolved.id = stripVersionAndTimeStamp(resolved.id) + importeeQuery;
           }
 
           return resolved;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail.  Include the package name if applicable. -->

This plugin potentially incorrectly resolves ids that already contain a query parameter by appending another: `foo.marko?v=1234?marko-server-entry`. Changes in Marko Run to write files to `/node_modules/.marko` surfaced this, as now those files get resolved with a version query. I'm not sure this is really the right fix (it doesn't handle any other query parameters) or if this is a symptom of a different issue.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
