### PR TITLE
feat: support css modules

### DIFF
--- a/.changeset/serious-zebras-tell.md
+++ b/.changeset/serious-zebras-tell.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": minor
+---
+
+Support CSS modules

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,10 +124,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
   const resolveVirtualDependency: compiler.Config["resolveVirtualDependency"] =
     (from, dep) => {
       const normalizedFrom = normalizePath(from);
-      const query = `${virtualFileQuery}&id=${
-        Buffer.from(dep.virtualPath).toString("base64url") +
-        path.extname(dep.virtualPath)
-      }`;
+      const query = `${virtualFileQuery}&id=${encodeURIComponent(dep.virtualPath)}`;
       const id = normalizedFrom + query;
 
       if (devServer) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Vite detects if file is CSS module though `.module.css` file ending, while using `extname` only keeps `.css`.
Use `encodeURIComponent` instead as it seems better than reimplementing part of the Vites detection logic.

`query` before: `?marko-virtual&id=Li91c2VyLiRpZCtwYWdlLm1hcmtvLm1vZHVsZS5jc3M.css`
`query` after: `?marko-virtual&id=.%2Fuser.%24id%2Bpage.marko.module.css`

Probably should add tests for this too, but I haven't done that.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
