### PR TITLE
fix: update options.input in options hook

### DIFF
--- a/.changeset/strange-tomatoes-buy.md
+++ b/.changeset/strange-tomatoes-buy.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+fix: update options.input in options hook

--- a/src/index.ts
+++ b/src/index.ts
@@ -495,7 +495,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
         }
       },
 
-      async buildStart(inputOptions) {
+      async options(inputOptions) {
         if (isBuild && linked && !isSSRBuild) {
           try {
             serverManifest = await store.read();
@@ -505,12 +505,6 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
               entryIds.add(id);
               cachedSources.set(id, serverManifest.entrySources[entry]);
             }
-            for (const assetId of serverManifest.ssrAssetIds) {
-              this.load({
-                id: normalizePath(path.resolve(root, assetId)),
-                resolveDependencies: false,
-              }).catch(noop);
-            }
           } catch (err) {
             this.error(
               `You must run the "ssr" build before the "browser" build.`,
@@ -519,6 +513,16 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
 
           if (isEmpty(inputOptions.input)) {
             this.error("No Marko files were found when compiling the server.");
+          }
+        }
+      },
+      async buildStart() {
+        if (isBuild && linked && !isSSRBuild) {
+          for (const assetId of serverManifest!.ssrAssetIds) {
+            this.load({
+              id: normalizePath(path.resolve(root, assetId)),
+              resolveDependencies: false,
+            }).catch(noop);
           }
         }
       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update `options.input` in `options` hook instead of `buildStart` hook.

<!--- Describe your changes in detail.  Include the package name if applicable. -->

## Motivation and Context

[`options` hook](https://rollupjs.org/plugin-development/#options) is the recommended hook to update the options. `buildStart` hook is not meant to be used to update the option. In addition, rolldown does not allow updating the option in `buildStart` hook.
Without this PR, this plugin does not work with Rolldown powered Vite. But with this PR, the tests passes 🙂

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated/added documentation affected by my changes. (it's an internal change)
- [x] I have added tests to cover my changes. (it's more a refactor than a fix)

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
