### PR TITLE
fix: optional vite asset inject to support non-entry templates

### DIFF
--- a/.changeset/afraid-impalas-fetch.md
+++ b/.changeset/afraid-impalas-fetch.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Make vite asset injection optional to support non-entry templates

--- a/src/__tests__/fixtures/isomorphic-custom-entries/src/other.marko
+++ b/src/__tests__/fixtures/isomorphic-custom-entries/src/other.marko
@@ -1,3 +1,4 @@
+<head/>
 <div>
   Hello
 </div>

--- a/src/render-assets-transform.ts
+++ b/src/render-assets-transform.ts
@@ -10,12 +10,13 @@ export default (tag: types.NodePath<types.MarkoTag>, t: typeof types) => {
 
 function renderAssetsCall(t: typeof types, slot: string) {
   return t.markoPlaceholder(
-    t.callExpression(
+    t.optionalCallExpression(
       t.memberExpression(
         t.identifier("$global"),
         t.identifier("___viteRenderAssets"),
       ),
       [t.stringLiteral(slot)],
+      true,
     ),
     false,
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Makes the vite injection script optional to support `<head>` and `<body>` tags used in non-entry templates.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
