### PR TITLE
fix: live reload tags api

### DIFF
--- a/.changeset/light-dolls-remain.md
+++ b/.changeset/light-dolls-remain.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Fix issue with child template analysis in marko 6 not causing parent modules to invalidate.

--- a/src/__tests__/fixtures/isomorphic-basic-hmr/__snapshots__/build.expected.md
+++ b/src/__tests__/fixtures/isomorphic-basic-hmr/__snapshots__/build.expected.md
@@ -1,0 +1,23 @@
+# Loading
+
+```html
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: true Clicks: 0
+  </div>
+</div>
+```
+
+# Step 0
+await page.click("#clickable")
+
+```diff
+-    Mounted: true Clicks: 0
++    Mounted: true Clicks: 1
+
+```
+

--- a/src/__tests__/fixtures/isomorphic-basic-hmr/__snapshots__/dev-hmr.expected.md
+++ b/src/__tests__/fixtures/isomorphic-basic-hmr/__snapshots__/dev-hmr.expected.md
@@ -1,0 +1,32 @@
+# Loading
+
+```html
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: true Clicks: 0
+  </div>
+</div>
+```
+
+# Step 0
+await page.click("#clickable")
+
+```diff
+-    Mounted: true Clicks: 0
++    Mounted: true Clicks: 1
+
+```
+
+# HMR 0
+src/components/class-component.marko: "Clicks: ${state.clickCount}" → "Click count: ${state.clickCount}"
+
+```diff
+-    Mounted: true Clicks: 1
++    Mounted: true Click count: 1
+
+```
+

--- a/src/__tests__/fixtures/isomorphic-basic-hmr/__snapshots__/dev.expected.md
+++ b/src/__tests__/fixtures/isomorphic-basic-hmr/__snapshots__/dev.expected.md
@@ -1,0 +1,23 @@
+# Loading
+
+```html
+<div
+  id="implicit"
+>
+  <div
+    id="clickable"
+  >
+    Mounted: true Clicks: 0
+  </div>
+</div>
+```
+
+# Step 0
+await page.click("#clickable")
+
+```diff
+-    Mounted: true Clicks: 0
++    Mounted: true Clicks: 1
+
+```
+

--- a/src/__tests__/fixtures/isomorphic-basic-hmr/dev-server.mjs
+++ b/src/__tests__/fixtures/isomorphic-basic-hmr/dev-server.mjs
@@ -1,0 +1,43 @@
+// In dev we'll start a Vite dev server in middleware mode,
+// and forward requests to our http request handler.
+
+import { createRequire } from "module";
+import path from "path";
+import url from "url";
+import { createServer } from "vite";
+
+// change to import once marko-vite is updated to ESM
+const markoPlugin = createRequire(import.meta.url)("../../..").default;
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+const devServer = await createServer({
+  root: __dirname,
+  appType: "custom",
+  logLevel: "warn",
+  plugins: [markoPlugin()],
+  optimizeDeps: { force: true },
+  server: {
+    ws: false,
+    hmr: false,
+    middlewareMode: true,
+    watch: {
+      ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
+    },
+  },
+  build: {
+    assetsInlineLimit: 0,
+  },
+});
+
+export default devServer.middlewares.use(async (req, res, next) => {
+  try {
+    const { handler } = await devServer.ssrLoadModule(
+      path.join(__dirname, "./src/index.js"),
+    );
+    await handler(req, res, next);
+  } catch (err) {
+    devServer.ssrFixStacktrace(err);
+    return next(err);
+  }
+});

--- a/src/__tests__/fixtures/isomorphic-basic-hmr/server.mjs
+++ b/src/__tests__/fixtures/isomorphic-basic-hmr/server.mjs
@@ -1,0 +1,16 @@
+// In production, simply start up the http server.
+import { createServer } from "http";
+import path from "path";
+import serve from "serve-handler";
+import url from "url";
+
+import { handler } from "./dist/index.mjs";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const serveOpts = { public: path.resolve(__dirname, "dist") };
+
+export default createServer(async (req, res) => {
+  await handler(req, res);
+  if (res.headersSent) return;
+  await serve(req, res, serveOpts);
+});

--- a/src/__tests__/fixtures/isomorphic-basic-hmr/src/components/class-component.marko
+++ b/src/__tests__/fixtures/isomorphic-basic-hmr/src/components/class-component.marko
@@ -1,0 +1,20 @@
+class {
+  onCreate() {
+    this.state = {
+      clickCount: 0,
+      mounted: false
+    };
+  }
+  onMount() {
+    this.state.mounted = true;
+  }
+
+  handleClick() {
+    this.state.clickCount++;
+  }
+}
+
+<div#clickable onClick("handleClick")>
+  Mounted: ${state.mounted}
+  Clicks: ${state.clickCount}
+</div>

--- a/src/__tests__/fixtures/isomorphic-basic-hmr/src/components/implicit-component.marko
+++ b/src/__tests__/fixtures/isomorphic-basic-hmr/src/components/implicit-component.marko
@@ -1,0 +1,9 @@
+static {
+  if (typeof window === "object") {
+    document.body.firstElementChild.append("Loaded Implicit Component");
+  }
+}
+
+<div#implicit>
+  <class-component/>
+</div>

--- a/src/__tests__/fixtures/isomorphic-basic-hmr/src/components/layout-component.marko
+++ b/src/__tests__/fixtures/isomorphic-basic-hmr/src/components/layout-component.marko
@@ -1,0 +1,15 @@
+static {
+  if (typeof window === "object") {
+    document.body.firstElementChild.append("Loaded Layout Component");
+  }
+}
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Hello World</title>
+</head>
+<body>
+  <${input.renderBody}/>
+</body>
+</html>

--- a/src/__tests__/fixtures/isomorphic-basic-hmr/src/index.js
+++ b/src/__tests__/fixtures/isomorphic-basic-hmr/src/index.js
@@ -1,0 +1,9 @@
+import template from "./template.marko";
+
+export function handler(req, res) {
+  if (req.url === "/") {
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    template.render({}, res);
+  }
+}

--- a/src/__tests__/fixtures/isomorphic-basic-hmr/src/template.marko
+++ b/src/__tests__/fixtures/isomorphic-basic-hmr/src/template.marko
@@ -1,0 +1,9 @@
+style {
+  div { color: green }
+}
+
+<layout-component>
+  <div#app>
+    <implicit-component/>
+  </div>
+</layout-component>

--- a/src/__tests__/fixtures/isomorphic-basic-hmr/test.config.ts
+++ b/src/__tests__/fixtures/isomorphic-basic-hmr/test.config.ts
@@ -1,0 +1,15 @@
+export const ssr = true;
+export async function steps() {
+  await page.click("#clickable");
+}
+export const hmr = [
+  {
+    changes: [
+      [
+        "src/components/class-component.marko",
+        "Clicks: ${state.clickCount}",
+        "Click count: ${state.clickCount}",
+      ],
+    ],
+  },
+];

--- a/src/__tests__/fixtures/isomorphic-tags-api-hmr/__snapshots__/build.expected.md
+++ b/src/__tests__/fixtures/isomorphic-tags-api-hmr/__snapshots__/build.expected.md
@@ -1,0 +1,8 @@
+# Loading
+
+```html
+<div>
+  Hello World
+</div>
+```
+

--- a/src/__tests__/fixtures/isomorphic-tags-api-hmr/__snapshots__/dev-hmr.expected.md
+++ b/src/__tests__/fixtures/isomorphic-tags-api-hmr/__snapshots__/dev-hmr.expected.md
@@ -1,0 +1,26 @@
+# Loading
+
+```html
+<div>
+  Hello World
+</div>
+```
+
+# HMR 0
+src/tags/child-tag.marko: "Hello ${input.name}" → "Hi ${input.name}"
+
+```diff
+-  Hello World
++  Hi World
+
+```
+
+# HMR 1
+src/tags/child-tag.marko: "Hi ${input.name}" → "Hey ${JSON.parse(JSON.stringify(input)).name}"
+
+```diff
+-  Hi World
++  Hey World
+
+```
+

--- a/src/__tests__/fixtures/isomorphic-tags-api-hmr/__snapshots__/dev.expected.md
+++ b/src/__tests__/fixtures/isomorphic-tags-api-hmr/__snapshots__/dev.expected.md
@@ -1,0 +1,8 @@
+# Loading
+
+```html
+<div>
+  Hello World
+</div>
+```
+

--- a/src/__tests__/fixtures/isomorphic-tags-api-hmr/dev-server.mjs
+++ b/src/__tests__/fixtures/isomorphic-tags-api-hmr/dev-server.mjs
@@ -1,0 +1,43 @@
+// In dev we'll start a Vite dev server in middleware mode,
+// and forward requests to our http request handler.
+
+import { createRequire } from "module";
+import path from "path";
+import url from "url";
+import { createServer } from "vite";
+
+// change to import once marko-vite is updated to ESM
+const markoPlugin = createRequire(import.meta.url)("../../..").default;
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+const devServer = await createServer({
+  root: __dirname,
+  appType: "custom",
+  logLevel: "warn",
+  plugins: [markoPlugin()],
+  optimizeDeps: { force: true },
+  server: {
+    ws: false,
+    hmr: false,
+    middlewareMode: true,
+    watch: {
+      ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
+    },
+  },
+  build: {
+    assetsInlineLimit: 0,
+  },
+});
+
+export default devServer.middlewares.use(async (req, res, next) => {
+  try {
+    const { handler } = await devServer.ssrLoadModule(
+      path.join(__dirname, "./src/index.js"),
+    );
+    await handler(req, res, next);
+  } catch (err) {
+    devServer.ssrFixStacktrace(err);
+    return next(err);
+  }
+});

--- a/src/__tests__/fixtures/isomorphic-tags-api-hmr/server.mjs
+++ b/src/__tests__/fixtures/isomorphic-tags-api-hmr/server.mjs
@@ -1,0 +1,16 @@
+// In production, simply start up the http server.
+import { createServer } from "http";
+import path from "path";
+import serve from "serve-handler";
+import url from "url";
+
+import { handler } from "./dist/index.mjs";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const serveOpts = { public: path.resolve(__dirname, "dist") };
+
+export default createServer(async (req, res) => {
+  await handler(req, res);
+  if (res.headersSent) return;
+  await serve(req, res, serveOpts);
+});

--- a/src/__tests__/fixtures/isomorphic-tags-api-hmr/src/index.js
+++ b/src/__tests__/fixtures/isomorphic-tags-api-hmr/src/index.js
@@ -1,0 +1,9 @@
+import template from "./template.marko";
+
+export function handler(req, res) {
+  if (req.url === "/") {
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    template.render({}).pipe(res);
+  }
+}

--- a/src/__tests__/fixtures/isomorphic-tags-api-hmr/src/tags/child-tag.marko
+++ b/src/__tests__/fixtures/isomorphic-tags-api-hmr/src/tags/child-tag.marko
@@ -1,0 +1,1 @@
+<div>Hello ${input.name}</div>

--- a/src/__tests__/fixtures/isomorphic-tags-api-hmr/src/tags/layout.marko
+++ b/src/__tests__/fixtures/isomorphic-tags-api-hmr/src/tags/layout.marko
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Hello World</title>
+</head>
+<body>
+  <${input.content}/>
+</body>
+</html>

--- a/src/__tests__/fixtures/isomorphic-tags-api-hmr/src/template.marko
+++ b/src/__tests__/fixtures/isomorphic-tags-api-hmr/src/template.marko
@@ -1,0 +1,9 @@
+<style>
+  div { color: green }
+</style>
+
+<layout>
+  <div#app>
+    <child-tag name="World"/>
+  </div>
+</layout>

--- a/src/__tests__/fixtures/isomorphic-tags-api-hmr/test.config.ts
+++ b/src/__tests__/fixtures/isomorphic-tags-api-hmr/test.config.ts
@@ -1,0 +1,21 @@
+export const ssr = true;
+export const hmr = [
+  {
+    // Step 1: Simple text change in the child tag (should trigger live reload).
+    changes: [
+      ["src/tags/child-tag.marko", "Hello ${input.name}", "Hi ${input.name}"],
+    ],
+  },
+  {
+    // Step 2: Change child from destructured input to whole input reference.
+    // This changes the child's exported API (from $name to $input),
+    // which requires the parent template to be recompiled.
+    changes: [
+      [
+        "src/tags/child-tag.marko",
+        "Hi ${input.name}",
+        "Hey ${JSON.parse(JSON.stringify(input)).name}",
+      ],
+    ],
+  },
+];

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -31,6 +31,16 @@ declare namespace globalThis {
 declare let __loading__: Promise<void> | undefined;
 
 type Step = () => Promise<unknown> | unknown;
+type HMRChange = [file: string, find: string, replace: string];
+type HMRStep = { changes: HMRChange[]; steps?: Step | Step[] };
+
+interface FixtureConfig {
+  ssr: boolean;
+  steps?: Step | Step[];
+  hmr?: HMRStep[];
+  options?: Options;
+  env?: Record<string, string>;
+}
 
 const requireCwd = createRequire(process.cwd());
 let vite: typeof import("vite");
@@ -130,12 +140,9 @@ const FIXTURES = path.join(__dirname, "fixtures");
 for (const fixture of fs.readdirSync(FIXTURES)) {
   describe(fixture, () => {
     const dir = path.join(FIXTURES, fixture);
-    const config = requireCwd(path.join(dir, "test.config.ts")) as {
-      ssr: boolean;
-      steps?: Step | Step[];
-      options?: Options;
-      env?: Record<string, string>;
-    };
+    const config = requireCwd(
+      path.join(dir, "test.config.ts"),
+    ) as FixtureConfig;
 
     if (config.env) {
       const preservedEnv: [string, string | undefined | false][] = [];
@@ -218,6 +225,12 @@ for (const fixture of fs.readdirSync(FIXTURES)) {
           server.close();
         }
       });
+
+      if (config.hmr) {
+        it("dev (hmr)", async () => {
+          await testHMR(dir, config);
+        });
+      }
     } else {
       it("dev", async () => {
         const port = await getAvailablePort();
@@ -278,8 +291,179 @@ for (const fixture of fs.readdirSync(FIXTURES)) {
           await previewServer.close();
         }
       });
+
+      if (config.hmr) {
+        it("dev (hmr)", async () => {
+          await testHMR(dir, config);
+        });
+      }
     }
   });
+}
+
+async function testHMR(dir: string, config: FixtureConfig) {
+  const hmrSteps = config.hmr!;
+  const port = await getAvailablePort();
+  const originalFiles = new Map<string, string>();
+
+  // Create a dev server with HMR enabled.
+  // We use mode "development" (not "test") so the plugin enables HMR features
+  // (hot compiler flag, import.meta.hot.accept injection).
+  const devServer = await vite.createServer({
+    root: dir,
+    mode: "development",
+    appType: "custom",
+    logLevel: "error",
+    plugins: [markoPlugin(config.options)],
+    optimizeDeps: { force: true },
+    server: {
+      port,
+      hmr: true,
+      watch: {
+        ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
+      },
+    },
+    build: {
+      assetsInlineLimit: 0,
+    },
+  });
+
+  if (config.ssr) {
+    // For SSR fixtures, add middleware that handles SSR rendering.
+    devServer.middlewares.use(async (req, res, next) => {
+      try {
+        const { handler } = await devServer.ssrLoadModule(
+          path.join(dir, "./src/index.js"),
+        );
+        await handler(req, res, next);
+      } catch (err: any) {
+        devServer.ssrFixStacktrace(err);
+        return next(err);
+      }
+    });
+  }
+
+  try {
+    await devServer.listen();
+
+    // Navigate to the page and capture initial state.
+    await page.goto(`http://localhost:${port}`);
+
+    const title = await page.title();
+    if (title === "Error") {
+      const error = new Error("Error in response");
+      const html = await page.locator("pre").innerHTML();
+      if (html) {
+        error.stack = JSDOM.fragment(html.replace(/<br>/g, "\n")).textContent!;
+      }
+      throw error;
+    }
+
+    let snapshot = "";
+    let prevHtml: string | undefined;
+    let prevRawHtml: string | undefined;
+
+    await page.waitForSelector("#app");
+    snapshot += `# Loading\n\n`;
+    const html = await getHTML();
+    prevRawHtml = await getRawHTML();
+    snapshot += htmlSnapshot(html, prevHtml);
+    prevHtml = html;
+
+    // Run initial interaction steps if provided at top-level.
+    const initialSteps: Step[] = config.steps
+      ? Array.isArray(config.steps)
+        ? config.steps
+        : [config.steps]
+      : [];
+
+    for (const [i, step] of initialSteps.entries()) {
+      snapshot += `# Step ${i}\n${getStepString(step)}\n\n`;
+      await step();
+      const stepHtml = await getHTML();
+      if (stepHtml === prevHtml) continue;
+      snapshot += htmlSnapshot(stepHtml, prevHtml);
+      prevHtml = stepHtml;
+      prevRawHtml = await getRawHTML();
+    }
+
+    // Run HMR steps.
+    for (const [hmrIdx, hmrStep] of hmrSteps.entries()) {
+      // Apply file changes.
+      for (const [file, find, replace] of hmrStep.changes) {
+        const filePath = path.join(dir, file);
+        if (!originalFiles.has(filePath)) {
+          originalFiles.set(filePath, fs.readFileSync(filePath, "utf8"));
+        }
+        const content = fs.readFileSync(filePath, "utf8");
+        const newContent = content.replace(find, replace);
+        if (newContent === content) {
+          throw new Error(
+            `HMR change failed: could not find ${JSON.stringify(find)} in ${file}`,
+          );
+        }
+        fs.writeFileSync(filePath, newContent);
+      }
+
+      // Wait for HMR update to propagate to the browser.
+      // We watch for DOM changes on #app as a signal that HMR has taken effect.
+      await page
+        .waitForFunction(
+          (prev) => {
+            const app = document.getElementById("app");
+            return app && app.innerHTML !== prev;
+          },
+          prevRawHtml,
+          { timeout: 10000 },
+        )
+        .catch(() => {
+          // Timeout is acceptable — the HMR update may not change the #app content,
+          // or the page may have been fully reloaded.
+        });
+
+      const hmrHtml = await getHTML();
+      const changesDesc = hmrStep.changes
+        .map(
+          ([file, find, replace]) =>
+            `${file}: ${JSON.stringify(find)} → ${JSON.stringify(replace)}`,
+        )
+        .join("\n");
+      snapshot += `# HMR ${hmrIdx}\n${changesDesc}\n\n`;
+
+      if (hmrHtml !== prevHtml) {
+        snapshot += htmlSnapshot(hmrHtml, prevHtml);
+        prevHtml = hmrHtml;
+        prevRawHtml = await getRawHTML();
+      } else {
+        snapshot += `(no change)\n\n`;
+      }
+
+      // Run any post-HMR interaction steps.
+      const postSteps: Step[] = hmrStep.steps
+        ? Array.isArray(hmrStep.steps)
+          ? hmrStep.steps
+          : [hmrStep.steps]
+        : [];
+
+      for (const [i, step] of postSteps.entries()) {
+        snapshot += `# HMR ${hmrIdx} Step ${i}\n${getStepString(step)}\n\n`;
+        await step();
+        const stepHtml = await getHTML();
+        if (stepHtml === prevHtml) continue;
+        snapshot += htmlSnapshot(stepHtml, prevHtml);
+        prevHtml = stepHtml;
+        prevRawHtml = await getRawHTML();
+      }
+    }
+
+    await snap(snapshot, { ext: ".md", dir });
+  } finally {
+    // Restore all mutated files.
+    for (const [filePath, content] of originalFiles) {
+      fs.writeFileSync(filePath, content);
+    }
+    await devServer.close();
+  }
 }
 
 async function testPage(dir: string, steps: Step[], port: number) {
@@ -340,6 +524,10 @@ async function getHTML() {
     .replace(/-[a-z0-9_-]+(\.\w+)/gi, "-[hash]$1")
     .replace(/\/_[a-z0-9_-]+(\.\w+)/gi, "/[hash]$1")
     .replace(/[?&][tv]=[\d.]+/, "");
+}
+
+async function getRawHTML() {
+  return page.evaluate(() => document.getElementById("app")?.innerHTML || "");
 }
 
 async function getAvailablePort() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,6 +178,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
   const entryIds = new Set<string>();
   const cachedSources = new Map<string, string>();
   const transformWatchFiles = new Map<string, string[]>();
+  const transformAnalyzedTags = new Map<string, Set<string>>();
   const store = new ReadOncePersistedStore<ServerManifest>(
     `vite-marko${runtimeId ? `-${runtimeId}` : ""}`,
   );
@@ -466,6 +467,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
           if (type === "unlink") {
             entryIds.delete(fileName);
             transformWatchFiles.delete(fileName);
+            transformAnalyzedTags.delete(fileName);
           }
 
           for (const [id, files] of transformWatchFiles) {
@@ -489,7 +491,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
         });
       },
 
-      handleHotUpdate(ctx) {
+      hotUpdate(ctx) {
         compiler.taglib.clearCaches();
         baseConfig.cache!.clear();
         clearScanCache();
@@ -498,6 +500,27 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
           if (mod.id && virtualFiles.has(mod.id)) {
             virtualFiles.set(mod.id, createDeferredPromise());
           }
+        }
+
+        // When a child tag template changes, parent templates that analyzed
+        // it may need recompilation (e.g., input destructuring changes in
+        // Tags API affect the parent's compiled output).
+        const fileName = normalizePath(ctx.file);
+        let extraModules: undefined | typeof ctx.modules;
+        for (const [parent, files] of transformAnalyzedTags) {
+          if (parent !== fileName && files.has(fileName)) {
+            const mods = this.environment.moduleGraph.getModulesByFile(parent);
+            if (mods) {
+              extraModules ||= [];
+              for (const mod of mods) {
+                extraModules.push(mod);
+              }
+            }
+          }
+        }
+
+        if (extraModules) {
+          return [...ctx.modules, ...extraModules];
         }
       },
 
@@ -753,18 +776,29 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
             }
           }
 
+          let markoAPI: string | undefined;
+          if ("transformRequest" in this.environment) {
+            const entryMod =
+              this.environment.moduleGraph.getModuleById(fileName);
+            await this.environment.transformRequest(fileName);
+            markoAPI = this.getModuleInfo(fileName)?.meta.markoAPI;
+            // transformRequest above re-populates the module's transformResult
+            // which prevents the SSR module runner from detecting that it was
+            // invalidated. Re-invalidate so the runner properly re-evaluates it.
+
+            if (entryMod) {
+              this.environment.moduleGraph.invalidateModule(entryMod);
+            }
+          } else {
+            markoAPI = (await this.load({ id: fileName }))?.meta.markoAPI;
+          }
+
           source = await getServerEntryTemplate({
             fileName,
             entryData,
             runtimeId,
             basePathVar: isBuild ? basePathVar : undefined,
-            tagsAPI: isTagsApi(
-              ("transformRequest" in this.environment
-                ? (await this.environment.transformRequest(fileName),
-                  this.getModuleInfo(fileName))
-                : await this.load({ id: fileName })
-              )?.meta.markoAPI,
-            ),
+            tagsAPI: isTagsApi(markoAPI),
           });
         }
 
@@ -848,6 +882,13 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
 
         if (devServer) {
           transformWatchFiles.set(id, meta.watchFiles);
+          if (meta.analyzedTags) {
+            const files = new Set<string>();
+            transformAnalyzedTags.set(id, files);
+            for (const file of meta.analyzedTags) {
+              files.add(normalizePath(file));
+            }
+          }
         } else {
           for (const file of meta.watchFiles) {
             this.addWatchFile(file);


### PR DESCRIPTION
* Fix issue with live reloading tags api components when child template changes it's `input` usage.