### PR TITLE
chore: use types from Vite

### DIFF
--- a/src/rolldown-plugin.ts
+++ b/src/rolldown-plugin.ts
@@ -1,6 +1,6 @@
 import * as compiler from "@marko/compiler";
 import path from "path";
-import type { Rolldown } from "rolldown";
+import type { Rolldown } from "vite";
 
 import { normalizePath } from "./normalize-path";
 import { scan } from "./scan";

--- a/src/rolldown-plugin.ts
+++ b/src/rolldown-plugin.ts
@@ -1,6 +1,6 @@
 import * as compiler from "@marko/compiler";
 import path from "path";
-import type { ModuleType, Plugin } from "rolldown";
+import type { Rolldown } from "rolldown";
 
 import { normalizePath } from "./normalize-path";
 import { scan } from "./scan";
@@ -12,7 +12,7 @@ export default function rolldownPlugin(
   config: compiler.Config,
   virtualFiles: Map<string, { code: string } | Promise<{ code: string }>>,
   cacheVirtualFile: (path: string) => Promise<undefined | string>,
-): Plugin[] {
+): Rolldown.Plugin[] {
   const baseConfig: compiler.Config = {
     ...config,
     hot: false,
@@ -47,7 +47,7 @@ export default function rolldownPlugin(
           return (
             file && {
               code: (await file).code,
-              moduleType: path.extname(id).slice(1) as ModuleType,
+              moduleType: path.extname(id).slice(1) as Rolldown.ModuleType,
             }
           );
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use types from `vite` rather than from `rolldown`.

## Motivation and Context

`rolldown` is not a dependency / devDeps of this package and is not always possible to import depending on the package manager's behavior. On ecosystem-ci, `vite` is resolved to the local `vite` so `node_modules/rolldown` will not be created by npm, thus the type fails to resolve.
https://github.com/vitejs/vite-ecosystem-ci/actions/runs/27599464088/job/81596799094
This PR would fix the error above by using the types re-exported from `vite`.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated/added documentation affected by my changes. (it's an internal change)
- [x] I have added tests to cover my changes. (ecosystem-ci is the tests)

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
