### PR TITLE
Improve tree-shaking of server-only content

### DIFF
--- a/.changeset/side-effect-free-imports.md
+++ b/.changeset/side-effect-free-imports.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Improve tree-shaking of server-only content in client builds. A template's imports are now treated as side effect free unless they're a `.marko` file, a client side asset, or an explicit bare `import "x"` — so an `import { onlyServer }` used only in a `server` block drops from the client bundle instead of being pulled in for its assumed side effects.

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 !**/__tests__/**/node_modules/test-package2
 !**/__tests__/**/node_modules/dep
 !**/__tests__/**/node_modules/transient-dep
+!**/__tests__/**/node_modules/impure-lib
 npm-debug.log
 
 # Build

--- a/src/__tests__/fixtures/browser-side-effects/__snapshots__/build.expected.md
+++ b/src/__tests__/fixtures/browser-side-effects/__snapshots__/build.expected.md
@@ -1,0 +1,19 @@
+# Loading
+
+```html
+<div
+  class="marko-side-effects"
+>
+  <div
+    id="shared"
+  >
+    shared: shared-value
+  </div>
+  <div
+    id="loaded"
+  >
+    loaded: explicit-side-effect
+  </div>
+</div>
+```
+

--- a/src/__tests__/fixtures/browser-side-effects/__snapshots__/dev.expected.md
+++ b/src/__tests__/fixtures/browser-side-effects/__snapshots__/dev.expected.md
@@ -1,0 +1,19 @@
+# Loading
+
+```html
+<div
+  class="marko-side-effects"
+>
+  <div
+    id="shared"
+  >
+    shared: shared-value
+  </div>
+  <div
+    id="loaded"
+  >
+    loaded: explicit-side-effect, impure-lib, server-only
+  </div>
+</div>
+```
+

--- a/src/__tests__/fixtures/browser-side-effects/index.html
+++ b/src/__tests__/fixtures/browser-side-effects/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/index.js"></script>
+  </body>
+</html>

--- a/src/__tests__/fixtures/browser-side-effects/node_modules/impure-lib/index.js
+++ b/src/__tests__/fixtures/browser-side-effects/node_modules/impure-lib/index.js
@@ -1,0 +1,7 @@
+// Ordinary package with no `sideEffects` field. Its only export is server-only,
+// so the whole module (and this side effect) should tree-shake from the client.
+(globalThis.__markoLoaded ??= []).push("impure-lib");
+
+export function impureServerOnly() {
+  return "impure-server-only";
+}

--- a/src/__tests__/fixtures/browser-side-effects/node_modules/impure-lib/package.json
+++ b/src/__tests__/fixtures/browser-side-effects/node_modules/impure-lib/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "impure-lib",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js"
+}

--- a/src/__tests__/fixtures/browser-side-effects/src/explicit-side-effect.js
+++ b/src/__tests__/fixtures/browser-side-effects/src/explicit-side-effect.js
@@ -1,0 +1,4 @@
+import { loaded } from "./tracker.js";
+
+// An explicit bare `import "x"` side effect — must always run on the client.
+loaded.push("explicit-side-effect");

--- a/src/__tests__/fixtures/browser-side-effects/src/index.js
+++ b/src/__tests__/fixtures/browser-side-effects/src/index.js
@@ -1,0 +1,3 @@
+import template from "./template.marko";
+
+template.mount({}, document.getElementById("app"));

--- a/src/__tests__/fixtures/browser-side-effects/src/server-only.js
+++ b/src/__tests__/fixtures/browser-side-effects/src/server-only.js
@@ -1,0 +1,8 @@
+import { loaded } from "./tracker.js";
+
+// Runs only if this module ends up in the client bundle.
+loaded.push("server-only");
+
+export function onlyServer() {
+  return "server-only-result";
+}

--- a/src/__tests__/fixtures/browser-side-effects/src/shared.js
+++ b/src/__tests__/fixtures/browser-side-effects/src/shared.js
@@ -1,0 +1,1 @@
+export const shared = "shared-value";

--- a/src/__tests__/fixtures/browser-side-effects/src/styles.css
+++ b/src/__tests__/fixtures/browser-side-effects/src/styles.css
@@ -1,0 +1,3 @@
+.marko-side-effects {
+  color: rgb(0, 128, 0);
+}

--- a/src/__tests__/fixtures/browser-side-effects/src/template.marko
+++ b/src/__tests__/fixtures/browser-side-effects/src/template.marko
@@ -1,0 +1,18 @@
+import { onlyServer } from "./server-only.js";
+import { impureServerOnly } from "impure-lib";
+import { shared } from "./shared.js";
+import { loaded } from "./tracker.js";
+import "./explicit-side-effect.js";
+import "./styles.css";
+
+// `onlyServer`/`impureServerOnly` are used only in a server block, so they (and
+// `impure-lib`, which has no `sideEffects` field) tree-shake out of the client.
+server {
+  onlyServer();
+  impureServerOnly();
+}
+
+<div.marko-side-effects>
+  <div id="shared">shared: ${shared}</div>
+  <div id="loaded">loaded: ${loaded.slice().sort().join(", ")}</div>
+</div>

--- a/src/__tests__/fixtures/browser-side-effects/src/tracker.js
+++ b/src/__tests__/fixtures/browser-side-effects/src/tracker.js
@@ -1,0 +1,3 @@
+// Records which side-effect modules ran on the client. On a global so the
+// `impure-lib` package shares it; the template renders the result.
+export const loaded = (globalThis.__markoLoaded ??= []);

--- a/src/__tests__/fixtures/browser-side-effects/test.config.ts
+++ b/src/__tests__/fixtures/browser-side-effects/test.config.ts
@@ -1,0 +1,3 @@
+// Browser fixture: the render lists which side-effect modules ran. The build
+// tree-shakes server-only ones out; the bare and used imports remain.
+export {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,9 @@ const virtualFilesForTemplate = new Map<string, Set<string>>();
 const virtualFilesResetForTemplate = new Map<string, number>();
 const ssrTransformCache = new Map<string, string>();
 const importTagReg = /^<([^>]+)>$/;
+// Styles Vite's `assetsInclude` skips (it handles css/preprocessors itself).
+const styleImportReg =
+  /\.(?:css|less|s[ac]ss|styl(?:us)?|pcss|postcss)(?:\?|$)/i;
 const optionalWatchFileReg =
   /[\\/](?:([^\\/]+)\.)?(?:marko-tag.json|(?:style|component|component-browser)\.\w+)$/;
 const noClientAssetsRuntimeId = "\0no_client_bundles.mjs";
@@ -200,6 +203,9 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
   let devEntryFilePosix: string;
   let renderAssetsRuntimeCode: string;
   let linkAssetsRuntimeCode: string;
+  // Vite's asset matcher (set in `configResolved`); excludes css, so
+  // `isSideEffectFile` adds styles + `.marko`.
+  let viteAssetsInclude: (file: string) => boolean = () => false;
   let isTest = false;
   let isBuild = false;
   let hasBuildApp = false;
@@ -216,10 +222,16 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
   const cachedSources = new Map<string, string>();
   const transformWatchFiles = new Map<string, string[]>();
   const transformAnalyzedTags = new Map<string, Set<string>>();
+  // Resolved ids of a template's explicit bare `import "x"` imports (filled in
+  // `transform`); the treeshake hook keeps these, everything else is shakeable.
+  const markoSideEffectImportIds = new Set<string>();
   const store = new ReadOncePersistedStore<ServerManifest>(
     `vite-marko${runtimeId ? `-${runtimeId}` : ""}`,
   );
   const isTagsApi = (api: undefined | string) => api === "tags";
+  // Kept purely by path: a `.marko` file, a style, or a Vite asset.
+  const isSideEffectFile = (file: string) =>
+    isMarkoFile(file) || styleImportReg.test(file) || viteAssetsInclude(file);
 
   return [
     {
@@ -325,11 +337,17 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
         clientConfig = {
           ...baseConfig,
           output: "dom",
+          // In build, keep the compiled AST so `transform` can read a template's
+          // side effect imports for tree-shaking without re-parsing (see below).
+          ast: isBuild,
         };
         clientEntryConfig = {
           ...baseConfig,
           output: "hydrate",
           sourceMaps: false,
+          // Also keep the AST here so the page entry's own side effect imports
+          // (eg the assets a server only page links in) are captured too.
+          ast: isBuild,
         };
         serverConfig = {
           ...baseConfig,
@@ -456,8 +474,8 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
 
         if (isBuild) {
           config.build ??= {};
-          if (!config.build.rolldownOptions?.output) {
-            config.build.rolldownOptions ??= {};
+          config.build.rolldownOptions ??= {};
+          if (!config.build.rolldownOptions.output) {
             config.build.rolldownOptions.output = {
               // By default use `_[hash]` instead of `[name]-[hash]` because for chunk names the `[name]` is
               // not deterministic (it's based on chunk.moduleIds order).
@@ -468,6 +486,37 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
                 ? "_[hash].js"
                 : `${config.build?.assetsDir?.replace(/[/\\]$/, "") ?? "assets"}/_[hash].js`,
             };
+          }
+
+          if (!isSSR) {
+            // Marko is the only source of side effects: default every module to
+            // side effect free (kept: `.marko`, assets, and bare imports).
+            const treeshake = config.build.rolldownOptions.treeshake;
+            const userModuleSideEffects =
+              treeshake && typeof treeshake === "object"
+                ? treeshake.moduleSideEffects
+                : undefined;
+            // Only compose when we can defer to the user's value (a function or
+            // nothing); leave an explicit array/string/"no-external" untouched.
+            if (
+              treeshake !== false &&
+              (userModuleSideEffects == null ||
+                typeof userModuleSideEffects === "function")
+            ) {
+              config.build.rolldownOptions.treeshake = {
+                ...(typeof treeshake === "object" ? treeshake : undefined),
+                moduleSideEffects: (id, external) => {
+                  const userValue = userModuleSideEffects?.(id, external);
+                  if (userValue != null) return userValue;
+                  // Let vite handle externals as it normally would.
+                  if (external) return undefined;
+                  return markoSideEffectImportIds.has(id) ||
+                    isSideEffectFile(stripViteQueries(id))
+                    ? undefined
+                    : false;
+                },
+              };
+            }
           }
         } else {
           const optimizeDeps = (config.optimizeDeps ??= {});
@@ -524,6 +573,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
       configResolved(config) {
         basePath = config.base;
         cacheDir = config.cacheDir && normalizePath(config.cacheDir);
+        viteAssetsInclude = config.assetsInclude;
         getMarkoAssetFns = undefined;
         for (const plugin of config.plugins) {
           const fn = plugin.api?.getMarkoAssetCodeForEntry as
@@ -690,6 +740,11 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
       },
 
       async options(inputOptions) {
+        if (isBuild && this.environment.name !== "ssr") {
+          // Reset the per-build tree-shaking set (eg for `vite build --watch`).
+          markoSideEffectImportIds.clear();
+        }
+
         if (linked && isBuild) {
           if (this.environment.name === "ssr") {
             serverManifest = {
@@ -1046,6 +1101,31 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
 
         const { meta } = compiled;
         let { code } = compiled;
+
+        if (isBuild && !isSSR && compiled.ast) {
+          // Record every bare `import "x"` the template compiles to so the
+          // treeshake hook keeps it (externals are left for vite to handle).
+          let resolvingSideEffectImports: Promise<unknown>[] | undefined;
+          for (const node of compiled.ast.program.body) {
+            if (
+              node.type === "ImportDeclaration" &&
+              node.specifiers.length === 0
+            ) {
+              (resolvingSideEffectImports ??= []).push(
+                this.resolve(node.source.value, fileName, resolveOpts).then(
+                  (resolved) => {
+                    if (resolved && !resolved.external) {
+                      markoSideEffectImportIds.add(resolved.id);
+                    }
+                  },
+                ),
+              );
+            }
+          }
+          if (resolvingSideEffectImports) {
+            await Promise.all(resolvingSideEffectImports);
+          }
+        }
 
         if (isServerEntry && useLinkAssets) {
           // With the compiler's built-in asset orchestration the compiler


### PR DESCRIPTION
## Description

`@marko/vite` now treats a template's imports as side effect free in client builds unless they're a `.marko` file, a client side asset, or an explicit bare `import "x"` side effect import. So an `import { onlyServer }` that's referenced only from a `server` block — and therefore already tree-shaken out of the client — now drops its module from the bundle entirely instead of being retained for its assumed side effects.

The plugin reads each template's bare side effect imports off the compiled AST (build only) and applies this with a deterministic `treeshake.moduleSideEffects` hook that rolldown evaluates once the whole module graph is built. Assets reuse Vite's `assetsInclude` (plus styles), and `.marko` files and explicit bare imports are always kept.

## Motivation and Context

A server-only value import (e.g. one used only inside a `server` block) could still be pulled into the client bundle whenever the bundler couldn't prove the imported module was side effect free — quietly shipping server-only dependencies to the browser. Marko templates should be the only source of client side effects, so everything else a template imports is now safe to tree-shake.

## Screenshots (if appropriate):

N/A

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FqEwPh8nwQoQxjrWiMHus3)_