### PR TITLE
Guide agents from compile output to the marko cheatsheet

### DIFF
--- a/.changeset/compile-error-fix-guide.md
+++ b/.changeset/compile-error-fix-guide.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+When a coding agent is driving the terminal (detected via the env markers agents set, e.g. `CLAUDECODE`, `CURSOR_AGENT`, `GEMINI_CLI`, `AI_AGENT`) and the installed marko package ships an LLM syntax reference, compile errors now end with a fix-guide pointer: "Fix guide: READ node_modules/marko/cheatsheet.md before writing a fix." Projects whose marko version does not ship `cheatsheet.md` — and all human-driven terminals — are unaffected.

--- a/.changeset/drop-resolve-package.md
+++ b/.changeset/drop-resolve-package.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+CommonJS module detection (`isCJSModule`) now resolves through `resolve-sync` instead of the legacy `resolve` package, removing `@marko/vite`'s last direct dependency on `resolve`. Behavior is unchanged: the resolved package's `package.json` is inspected the same way, including packages whose exports map exposes no resolvable entry.

--- a/.changeset/surface-warning-diagnostics.md
+++ b/.changeset/surface-warning-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Marko compile warnings are now printed to the dev/build terminal as `[marko] warning: <file>:<line> <message>`, once per file and source version. Previously warning diagnostics were only visible to editors via the language server.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "htmljs-parser": "^5.10.2",
         "htmlparser2": "^10.1.0",
         "relative-import-path": "^1.0.0",
-        "resolve-sync": "^1.2.1",
+        "resolve-sync": "^1.2.2",
         "resolve.exports": "^2.0.3"
       },
       "devDependencies": {
@@ -8243,9 +8243,9 @@
       }
     },
     "node_modules/resolve-sync": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-sync/-/resolve-sync-1.2.1.tgz",
-      "integrity": "sha512-S0oXAR5gZdWDWCmokO62Xs/SOIbq4os7rAcPrcBPiRi5rUAOxREdr11skiIX/T+aaFcQgGkBxuU8drFOvqSbCA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/resolve-sync/-/resolve-sync-1.2.2.tgz",
+      "integrity": "sha512-qq4M0+Gxgiohxw0MUYprQiNWzYKMqCvVgpZO0Imwd1TttPIWT9NxUco8UUtIiRpiJpHPWRhhYIaiuo7EYBcv5Q==",
       "license": "MIT",
       "dependencies": {
         "resolve.exports": "^2.0.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "htmljs-parser": "^5.10.2",
         "htmlparser2": "^10.1.0",
         "relative-import-path": "^1.0.0",
-        "resolve": "^1.22.11",
         "resolve-sync": "^1.2.1",
         "resolve.exports": "^2.0.3"
       },
@@ -33,7 +32,6 @@
         "@types/jsdom": "^28.0.0",
         "@types/mocha": "^10.0.10",
         "@types/node": "^25.5.0",
-        "@types/resolve": "^1.20.6",
         "@types/serve-handler": "^6.1.4",
         "cross-env": "^10.1.0",
         "diff": "^8.0.3",
@@ -3143,13 +3141,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/resolve": {
-      "version": "1.20.6",
-      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
-      "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/serve-handler": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/@types/serve-handler/-/serve-handler-6.1.4.tgz",
@@ -4564,15 +4555,6 @@
         "stackframe": "^1.3.4"
       }
     },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
@@ -5191,15 +5173,6 @@
         "node": ">=6 <7 || >=8"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -5393,18 +5366,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/he": {
@@ -5602,21 +5563,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -7866,12 +7812,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "license": "MIT"
-    },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -8281,27 +8221,6 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/resolve": {
-      "version": "1.22.12",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
@@ -9047,18 +8966,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/symbol-tree": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "htmlparser2": "^10.1.0",
         "relative-import-path": "^1.0.0",
         "resolve": "^1.22.11",
+        "resolve-sync": "^1.2.1",
         "resolve.exports": "^2.0.3"
       },
       "devDependencies": {
@@ -8320,6 +8321,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/resolve-sync": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-sync/-/resolve-sync-1.2.1.tgz",
+      "integrity": "sha512-S0oXAR5gZdWDWCmokO62Xs/SOIbq4os7rAcPrcBPiRi5rUAOxREdr11skiIX/T+aaFcQgGkBxuU8drFOvqSbCA==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve.exports": "^2.0.3"
       }
     },
     "node_modules/resolve.exports": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "htmljs-parser": "^5.10.2",
     "htmlparser2": "^10.1.0",
     "relative-import-path": "^1.0.0",
-    "resolve": "^1.22.11",
     "resolve-sync": "^1.2.1",
     "resolve.exports": "^2.0.3"
   },
@@ -65,7 +64,6 @@
     "@types/jsdom": "^28.0.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.5.0",
-    "@types/resolve": "^1.20.6",
     "@types/serve-handler": "^6.1.4",
     "cross-env": "^10.1.0",
     "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "htmlparser2": "^10.1.0",
     "relative-import-path": "^1.0.0",
     "resolve": "^1.22.11",
+    "resolve-sync": "^1.2.1",
     "resolve.exports": "^2.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "htmljs-parser": "^5.10.2",
     "htmlparser2": "^10.1.0",
     "relative-import-path": "^1.0.0",
-    "resolve-sync": "^1.2.1",
+    "resolve-sync": "^1.2.2",
     "resolve.exports": "^2.0.3"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import glob from "fast-glob";
 import fs from "fs";
 import path from "path";
 import { relativeImportPath } from "relative-import-path";
+import { resolveSync } from "resolve-sync";
 import type * as vite from "vite";
 
 import cjsInteropTranslate, {
@@ -141,6 +142,17 @@ let registeredTagLib = false;
 
 function noop(): undefined {}
 
+// Env markers set by terminal coding agents (Claude Code, Cursor, Gemini CLI,
+// Codex, and the generic AI_AGENT convention).
+const isCodingAgent =
+  process.env.CLAUDECODE ||
+  process.env.CLAUDE_CODE ||
+  process.env.CURSOR_AGENT ||
+  process.env.GEMINI_CLI ||
+  process.env.CODEX_SANDBOX ||
+  process.env.CODEX_THREAD_ID ||
+  process.env.AI_AGENT;
+
 export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
   let { linked = true } = opts;
   let runtimeId: string | undefined;
@@ -199,6 +211,70 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
   let root: string;
   let cacheDir: string | undefined;
   let rootResolveFile: string;
+  // Appended to compile errors when a coding agent is driving the terminal
+  // and the installed marko package ships an LLM syntax reference
+  // (cheatsheet.md); humans never see it. false = checked and absent.
+  let markoFixGuide: string | false | undefined;
+
+  function getMarkoFixGuide(): string | false {
+    if (markoFixGuide === undefined) {
+      markoFixGuide = false;
+      if (isCodingAgent) {
+        const cheatsheet = resolveSync("marko/cheatsheet.md", {
+          from: rootResolveFile,
+          silent: true,
+        });
+        if (cheatsheet) {
+          markoFixGuide = `\n\nFix guide: READ ${path.relative(root, cheatsheet)} before writing a fix.`;
+        }
+      }
+    }
+    return markoFixGuide;
+  }
+
+  // Warning diagnostics print once per file+source version (the html and dom
+  // compiles of the same source share one print; edits reprint).
+  const printedWarnings = new Map<
+    string,
+    { source: string; labels: Set<string> }
+  >();
+
+  async function compileWithFixGuide(
+    source: string,
+    filename: string,
+    config: compiler.Config,
+  ) {
+    try {
+      const result = await compiler.compile(source, filename, config);
+      let printed = printedWarnings.get(filename);
+      if (printed?.source !== source) {
+        printedWarnings.set(
+          filename,
+          (printed = { source, labels: new Set() }),
+        );
+      }
+      for (const diag of result.meta.diagnostics) {
+        if (diag.type === "warning" && !printed.labels.has(diag.label)) {
+          printed.labels.add(diag.label);
+          const loc = diag.loc ? `:${diag.loc.start.line}` : "";
+          console.warn(
+            `[marko] warning: ${path.relative(root, filename)}${loc} ${diag.label}`,
+          );
+        }
+      }
+      return result;
+    } catch (err) {
+      const fixGuide = getMarkoFixGuide();
+      if (
+        fixGuide &&
+        err instanceof Error &&
+        !err.message.includes("cheatsheet.md")
+      ) {
+        err.message += fixGuide;
+      }
+      throw err;
+    }
+  }
   let devEntryFile: string;
   let devEntryFilePosix: string;
   let renderAssetsRuntimeCode: string;
@@ -1066,7 +1142,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
 
           if (!info && isCJSModule(id, rootResolveFile)) {
             if (isBuild) {
-              const { code, map, meta } = await compiler.compile(
+              const { code, map, meta } = await compileWithFixGuide(
                 source,
                 id,
                 serverCJSConfig,
@@ -1081,7 +1157,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
           }
         }
 
-        const compiled = await compiler.compile(
+        const compiled = await compileWithFixGuide(
           source,
           fileName,
           isSSR

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import Resolve, { type Opts as ResolveOpts } from "resolve";
+import { resolveSync } from "resolve-sync";
 
 const moduleNameReg = /^(?:@[^/\\]+[/\\])?[^/\\]+/;
 const modulePathReg =
@@ -21,31 +21,49 @@ export function isCJSModule(id: string, fromFile: string): boolean {
   let isCJS = cjsModuleLookup.get(moduleId);
 
   if (isCJS === undefined) {
-    try {
-      if (isAbsolute) {
+    if (isAbsolute) {
+      try {
         const pkgPath = path.join(modulePathReg.exec(id)![0], "package.json");
-        const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
-        isCJS = pkg.type !== "module" && !pkg.exports;
-      } else {
-        Resolve.sync(moduleId + "/package.json", {
-          basedir: path.dirname(fromFile),
-          filename: fromFile,
-          pathFilter(
-            pkg: Record<string, unknown>,
-            _pkgFile: string,
-            relativePath: string,
-          ) {
-            isCJS = pkg.type !== "module" && !pkg.exports;
-            return relativePath;
-          },
-        } as ResolveOpts);
-        isCJS ??= false;
+        isCJS = isCJSPkg(JSON.parse(fs.readFileSync(pkgPath, "utf8")));
+      } catch {
+        // ignore
       }
-    } catch {
-      isCJS = false;
+    } else {
+      // The resolved entry point is unused; the fs hook captures the
+      // package.json of the package the resolver picks, which works even
+      // when its exports map does not expose an entry to resolve.
+      resolveSync(moduleId, {
+        from: fromFile,
+        silent: true,
+        fs: {
+          isFile(file) {
+            try {
+              return fs.statSync(file).isFile();
+            } catch {
+              return false;
+            }
+          },
+          readPkg(file) {
+            try {
+              const pkg = JSON.parse(fs.readFileSync(file, "utf8"));
+              if (pkg && typeof pkg === "object") {
+                isCJS ??= isCJSPkg(pkg);
+              }
+              return pkg;
+            } catch {
+              // ignore
+            }
+          },
+        },
+      });
     }
-    cjsModuleLookup.set(moduleId, isCJS);
+
+    cjsModuleLookup.set(moduleId, (isCJS ??= false));
   }
 
   return isCJS;
+}
+
+function isCJSPkg(pkg: { type?: unknown; exports?: unknown }): boolean {
+  return pkg.type !== "module" && !pkg.exports;
 }


### PR DESCRIPTION
## Description

Two additions to what the dev/build terminal says about Marko templates, aimed at coding agents that read compile output:

- **Compile errors end with an imperative pointer** — `Fix guide: READ node_modules/marko/cheatsheet.md before writing a fix.` — appended only when both hold:
  - a terminal coding agent is detected (checked eagerly at module load via the env markers agents set: `CLAUDECODE`/`CLAUDE_CODE`, `CURSOR_AGENT`, `GEMINI_CLI`, `CODEX_SANDBOX`/`CODEX_THREAD_ID`, or the generic `AI_AGENT`), so humans never see it; and
  - the installed `marko` package exports a `cheatsheet.md` (marko-js/marko#3392 + marko-js/marko#3393), resolved with [`resolve-sync`](https://github.com/marko-js/resolve-sync)`@^1.2.1` as `marko/cheatsheet.md` and cached after the first lookup. Installations without the file (e.g. Marko 5) are unaffected.

  The pointer is scoped to this plugin's compile calls, so editors and the language server are untouched.
- **Compile warnings print to the terminal** as `[marko] warning: <file>:<line> <message>`, once per file and source version (the html/dom compiles of the same source share one print; edits reprint). Previously warning diagnostics were only visible to editors via the language server, so terminal-driven workflows never saw them.

Two changesets, one per behavior.

> [!NOTE]
> The pointer starts appearing once a marko release including marko-js/marko#3392 + marko-js/marko#3393 ships; resolve-sync@1.2.1 (exports subpath + `silent` support, marko-js/resolve-sync#10) is already published and pinned here, and the lookup was verified against it.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZUGLZL3YoBToFLSEv2Nys