### PR TITLE
fix: issue with explicit side effect modules not tracking downstream

### DIFF
--- a/.changeset/side-effect-import-propagation.md
+++ b/.changeset/side-effect-import-propagation.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Carry a template's explicit bare `import "x"` side effect marking downstream to the modules `x` itself imports. Previously only `x` was exempt from the client build's side effect free default, so a package whose effect lives in a module it bare-imports (eg terser installing `AST_Toplevel#resolve_defines` from `import "./global-defs.js"`) still had that module shaken out. Marko files, styles and assets remain non-propagating, so a template's own imports stay shakeable.

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 !**/__tests__/**/node_modules/dep
 !**/__tests__/**/node_modules/transient-dep
 !**/__tests__/**/node_modules/impure-lib
+!**/__tests__/**/node_modules/side-effect-lib
 npm-debug.log
 
 # Build

--- a/src/__tests__/fixtures/browser-side-effects/__snapshots__/build.expected.md
+++ b/src/__tests__/fixtures/browser-side-effects/__snapshots__/build.expected.md
@@ -12,7 +12,7 @@
   <div
     id="loaded"
   >
-    loaded: explicit-side-effect
+    loaded: explicit-side-effect, nested-side-effect, side-effect-lib/register
   </div>
 </div>
 ```

--- a/src/__tests__/fixtures/browser-side-effects/__snapshots__/dev.expected.md
+++ b/src/__tests__/fixtures/browser-side-effects/__snapshots__/dev.expected.md
@@ -12,7 +12,7 @@
   <div
     id="loaded"
   >
-    loaded: explicit-side-effect, impure-lib, server-only
+    loaded: explicit-side-effect, impure-lib, nested-side-effect, server-only, side-effect-lib/register
   </div>
 </div>
 ```

--- a/src/__tests__/fixtures/browser-side-effects/node_modules/side-effect-lib/index.js
+++ b/src/__tests__/fixtures/browser-side-effects/node_modules/side-effect-lib/index.js
@@ -1,0 +1,6 @@
+// Bare imported by the template. Like terser, the package entry holds no side
+// effect itself: the effect lives in a module it bare-imports, so marking only
+// the entry is not enough.
+import "./register.js";
+
+export function unused() {}

--- a/src/__tests__/fixtures/browser-side-effects/node_modules/side-effect-lib/package.json
+++ b/src/__tests__/fixtures/browser-side-effects/node_modules/side-effect-lib/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "side-effect-lib",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js"
+}

--- a/src/__tests__/fixtures/browser-side-effects/node_modules/side-effect-lib/register.js
+++ b/src/__tests__/fixtures/browser-side-effects/node_modules/side-effect-lib/register.js
@@ -1,0 +1,1 @@
+(globalThis.__markoLoaded ??= []).push("side-effect-lib/register");

--- a/src/__tests__/fixtures/browser-side-effects/src/explicit-side-effect.js
+++ b/src/__tests__/fixtures/browser-side-effects/src/explicit-side-effect.js
@@ -1,3 +1,6 @@
+// A bare import of its own: the marking has to reach it too.
+import "./nested-side-effect.js";
+
 import { loaded } from "./tracker.js";
 
 // An explicit bare `import "x"` side effect — must always run on the client.

--- a/src/__tests__/fixtures/browser-side-effects/src/nested-side-effect.js
+++ b/src/__tests__/fixtures/browser-side-effects/src/nested-side-effect.js
@@ -1,0 +1,6 @@
+import { loaded } from "./tracker.js";
+
+// Reached only through the bare `import "./nested-side-effect.js"` in
+// `explicit-side-effect.js`. Exports nothing, so it survives only if the
+// explicit side effect marking carries downstream.
+loaded.push("nested-side-effect");

--- a/src/__tests__/fixtures/browser-side-effects/src/template.marko
+++ b/src/__tests__/fixtures/browser-side-effects/src/template.marko
@@ -3,6 +3,7 @@ import { impureServerOnly } from "impure-lib";
 import { shared } from "./shared.js";
 import { loaded } from "./tracker.js";
 import "./explicit-side-effect.js";
+import "side-effect-lib";
 import "./styles.css";
 
 // `onlyServer`/`impureServerOnly` are used only in a server block, so they (and

--- a/src/index.ts
+++ b/src/index.ts
@@ -863,6 +863,33 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
         }
       },
       async resolveId(importee, importer, importOpts, ssr = importOpts.ssr) {
+        // An explicit bare `import "x"` only says *x* has side effects, but x's
+        // own side effects usually live in the modules it imports (eg terser
+        // installs `AST_Toplevel#resolve_defines` from a bare
+        // `import "./global-defs.js"`). Carry the marking downstream so the
+        // whole subgraph a template opted into keeps its side effects. This
+        // stops at `.marko`/style/asset ids, which are never added to the set,
+        // so a template's own imports stay shakeable.
+        if (
+          isBuild &&
+          !ssr &&
+          importer &&
+          markoSideEffectImportIds.has(importer)
+        ) {
+          const resolved = await this.resolve(importee, importer, {
+            ...importOpts,
+            skipSelf: true,
+          });
+
+          if (
+            resolved &&
+            !resolved.external &&
+            !isSideEffectFile(stripViteQueries(resolved.id))
+          ) {
+            markoSideEffectImportIds.add(resolved.id);
+          }
+        }
+
         switch (importee) {
           case cjsInteropHelpersId:
           case renderAssetsRuntimeId:
@@ -1181,6 +1208,9 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
         if (isBuild && !isSSR && compiled.ast) {
           // Record every bare `import "x"` the template compiles to so the
           // treeshake hook keeps it (externals are left for vite to handle).
+          // Files `isSideEffectFile` already keeps (`.marko`, styles, assets)
+          // are skipped: adding them would seed the propagation below with, eg,
+          // every page template, which would mark the entire client graph.
           let resolvingSideEffectImports: Promise<unknown>[] | undefined;
           for (const node of compiled.ast.program.body) {
             if (
@@ -1190,7 +1220,11 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
               (resolvingSideEffectImports ??= []).push(
                 this.resolve(node.source.value, fileName, resolveOpts).then(
                   (resolved) => {
-                    if (resolved && !resolved.external) {
+                    if (
+                      resolved &&
+                      !resolved.external &&
+                      !isSideEffectFile(stripViteQueries(resolved.id))
+                    ) {
                       markoSideEffectImportIds.add(resolved.id);
                     }
                   },


### PR DESCRIPTION
Carry a template's explicit bare `import "x"` side effect marking downstream to the modules `x` itself imports. Previously only `x` was exempt from the client build's side effect free default, so a package whose effect lives in a module it bare-imports (eg terser installing `AST_Toplevel#resolve_defines` from `import "./global-defs.js"`) still had that module shaken out. Marko files, styles and assets remain non-propagating, so a template's own imports stay shakeable.