### PR TITLE
fix: use changeset publish so releases are tagged and created

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint:eslint": "eslint -f unix .",
     "lint:prettier": "prettier \"./**/*{.ts,.js,.json,.md,.yml,rc}\"",
     "prepare": "husky",
-    "release": "npm run build && npm publish",
+    "release": "npm run build && changeset publish --tag ${NPM_CONFIG_TAG:-latest}",
     "report": "open ./coverage/lcov-report/index.html",
     "test": "cross-env NODE_ENV=test mocha \"./src/**/__tests__/*.test.ts\"",
     "test:inspect": "npm test -- --inspect",


### PR DESCRIPTION
## Description

Restore the `release` script to `changeset publish` (from `npm publish`).

## Motivation and Context

`npm publish` emits no `New tag:` output, so `changesets/action` stopped creating git tags and GitHub releases from 6.0.2 onward (npm and CHANGELOG kept working). `changeset publish` restores both, still honoring `NPM_CONFIG_TAG` for non-`latest` dist-tags.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qWqoXP5JA8K3uYr1RYfRg

---
_Generated by [Claude Code](https://claude.ai/code/session_015qWqoXP5JA8K3uYr1RYfRg)_