### PR TITLE
refactor: move agent cheat-sheet fix-guide into @marko/compiler

### DIFF
--- a/.changeset/remove-vite-fix-guide.md
+++ b/.changeset/remove-vite-fix-guide.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Move the coding-agent cheat-sheet fix-guide into `@marko/compiler`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import glob from "fast-glob";
 import fs from "fs";
 import path from "path";
 import { relativeImportPath } from "relative-import-path";
-import { resolveSync } from "resolve-sync";
 import type * as vite from "vite";
 
 import cjsInteropTranslate, {
@@ -142,17 +141,6 @@ let registeredTagLib = false;
 
 function noop(): undefined {}
 
-// Env markers set by terminal coding agents (Claude Code, Cursor, Gemini CLI,
-// Codex, and the generic AI_AGENT convention).
-const isCodingAgent =
-  process.env.CLAUDECODE ||
-  process.env.CLAUDE_CODE ||
-  process.env.CURSOR_AGENT ||
-  process.env.GEMINI_CLI ||
-  process.env.CODEX_SANDBOX ||
-  process.env.CODEX_THREAD_ID ||
-  process.env.AI_AGENT;
-
 export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
   let { linked = true } = opts;
   let runtimeId: string | undefined;
@@ -211,26 +199,6 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
   let root: string;
   let cacheDir: string | undefined;
   let rootResolveFile: string;
-  // Appended to compile errors when a coding agent is driving the terminal
-  // and the installed marko package ships an LLM syntax reference
-  // (cheatsheet.md); humans never see it. false = checked and absent.
-  let markoFixGuide: string | false | undefined;
-
-  function getMarkoFixGuide(): string | false {
-    if (markoFixGuide === undefined) {
-      markoFixGuide = false;
-      if (isCodingAgent) {
-        const cheatsheet = resolveSync("marko/cheatsheet.md", {
-          from: rootResolveFile,
-          silent: true,
-        });
-        if (cheatsheet) {
-          markoFixGuide = `\n\nFix guide: READ ${path.relative(root, cheatsheet)} before writing a fix.`;
-        }
-      }
-    }
-    return markoFixGuide;
-  }
 
   // Warning diagnostics print once per file+source version (the html and dom
   // compiles of the same source share one print; edits reprint).
@@ -239,41 +207,28 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
     { source: string; labels: Set<string> }
   >();
 
-  async function compileWithFixGuide(
+  // `@marko/compiler` annotates compile errors with the agent cheat-sheet
+  // pointer; here we only surface warning diagnostics to the terminal.
+  async function compileAndReportWarnings(
     source: string,
     filename: string,
     config: compiler.Config,
   ) {
-    try {
-      const result = await compiler.compile(source, filename, config);
-      let printed = printedWarnings.get(filename);
-      if (printed?.source !== source) {
-        printedWarnings.set(
-          filename,
-          (printed = { source, labels: new Set() }),
+    const result = await compiler.compile(source, filename, config);
+    let printed = printedWarnings.get(filename);
+    if (printed?.source !== source) {
+      printedWarnings.set(filename, (printed = { source, labels: new Set() }));
+    }
+    for (const diag of result.meta.diagnostics) {
+      if (diag.type === "warning" && !printed.labels.has(diag.label)) {
+        printed.labels.add(diag.label);
+        const loc = diag.loc ? `:${diag.loc.start.line}` : "";
+        console.warn(
+          `[marko] warning: ${path.relative(root, filename)}${loc} ${diag.label}`,
         );
       }
-      for (const diag of result.meta.diagnostics) {
-        if (diag.type === "warning" && !printed.labels.has(diag.label)) {
-          printed.labels.add(diag.label);
-          const loc = diag.loc ? `:${diag.loc.start.line}` : "";
-          console.warn(
-            `[marko] warning: ${path.relative(root, filename)}${loc} ${diag.label}`,
-          );
-        }
-      }
-      return result;
-    } catch (err) {
-      const fixGuide = getMarkoFixGuide();
-      if (
-        fixGuide &&
-        err instanceof Error &&
-        !err.message.includes("cheatsheet.md")
-      ) {
-        err.message += fixGuide;
-      }
-      throw err;
     }
+    return result;
   }
   let devEntryFile: string;
   let devEntryFilePosix: string;
@@ -1169,7 +1124,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
 
           if (!info && isCJSModule(id, rootResolveFile)) {
             if (isBuild) {
-              const { code, map, meta } = await compileWithFixGuide(
+              const { code, map, meta } = await compileAndReportWarnings(
                 source,
                 id,
                 serverCJSConfig,
@@ -1184,7 +1139,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
           }
         }
 
-        const compiled = await compileWithFixGuide(
+        const compiled = await compileAndReportWarnings(
           source,
           fileName,
           isSSR


### PR DESCRIPTION
## Description

The coding-agent cheat-sheet fix-guide now lives in `@marko/compiler` (companion marko PR), so it applies to every build tool. `@marko/vite` drops its own copy and keeps surfacing compile warnings to the terminal.

## Motivation and Context

Avoids duplicating agent detection + cheat-sheet resolution per build tool.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFHu9UdLb4gSB6YsmvZw8n)_