### PR TITLE
fix: keep CSS sourcemaps for `<style>` blocks in dev

### DIFF
--- a/.changeset/fix-scss-virtual-sourcemap-warning.md
+++ b/.changeset/fix-scss-virtual-sourcemap-warning.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Fix a spurious `Sourcemap for "<template>.marko-virtual.scss" points to missing source files` warning in dev when a `.marko` template has a `<style>` block. The dep optimizer compiled templates with `sourceMaps: "inline"`, which drops the extracted style block's separate sourcemap; the shared compiler cache then left the dev server serving the virtual CSS with no map to trace back to its template, so the style preprocessor emitted a self-referential map to the (non-existent) virtual file. The optimizer now uses `sourceMaps: "both"` so the separate map is retained, and the entry compile configs no longer force `sourceMaps: false` (the compiler now skips the entry wrapper's own map on its side), so CSS sourcemaps survive.

--- a/src/index.ts
+++ b/src/index.ts
@@ -375,7 +375,8 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
         clientEntryConfig = {
           ...baseConfig,
           output: "hydrate",
-          sourceMaps: false,
+          // `sourceMaps` stays on so extracted `<style>` maps survive; the
+          // compiler skips the entry wrapper's own (meaningless) map.
           // Also keep the AST here so the page entry's own side effect imports
           // (eg the assets a server only page links in) are captured too.
           ast: isBuild,
@@ -390,17 +391,17 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
         } as any;
         serverEntryConfig = {
           ...serverConfig,
+          // Legacy server entry: a plain `html` wrapper the compiler can't
+          // distinguish from a real template, so suppress its map here.
           sourceMaps: false,
         };
         serverEntryLinkConfig = {
           ...serverConfig,
           entry: "page",
-          sourceMaps: false,
         };
         clientLoadEntryConfig = {
           ...clientConfig,
           entry: "load",
-          sourceMaps: false,
         };
 
         compiler.configure(baseConfig);

--- a/src/rolldown-plugin.ts
+++ b/src/rolldown-plugin.ts
@@ -16,7 +16,9 @@ export default function rolldownPlugin(
   const baseConfig: compiler.Config = {
     ...config,
     hot: false,
-    sourceMaps: "inline",
+    // `both`, not `inline`: virtual files (eg `<style>` blocks) reach the dev
+    // server via shared `virtualFiles`, which needs the map `inline` drops.
+    sourceMaps: "both",
   };
   return [
     {


### PR DESCRIPTION
## Description

Fixes a spurious `Sourcemap for "<template>.marko-virtual.scss" points to missing source files` dev warning for templates with a `<style>` block.

The dep optimizer compiled `.marko` files with `sourceMaps: "inline"`, which drops the extracted style block's separate sourcemap; the shared compiler cache then left the dev server serving the virtual CSS with no map to trace it back to the template, so the style preprocessor emitted a self-referential map to the (non-existent) virtual file. The optimizer now uses `sourceMaps: "both"` (retains the separate map with source content), and the entry compile configs no longer force `sourceMaps: false`.

## Motivation and Context

Reported: templates with a `<style>` block emit the warning on a cold dev start. Depends on the paired compiler change (marko-js/marko#3428) so entry compiles keep CSS maps without also emitting a pointless entry-wrapper map.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AF5JjTrZTp37F1DVUUvUoJ)_