### PR TITLE
fix: known-template discovery must not follow symlinks

### DIFF
--- a/.changeset/known-templates-symlinks.md
+++ b/.changeset/known-templates-symlinks.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Stop following symlinks when discovering known templates for optimized builds: pnpm layouts link node_modules as cyclic symlink graphs, so the walk previously never terminated and exhausted the heap.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1681,6 +1681,10 @@ function getKnownTemplates(cwd: string) {
         {
           cwd,
           absolute: true,
+          // The node_modules pattern forces the walk into package trees, and
+          // pnpm layouts link those as cyclic symlink graphs — following the
+          // links walks forever and OOMs the build.
+          followSymbolicLinks: false,
           ignore: [
             "**/*.d.marko",
             "**/*build*/**",


### PR DESCRIPTION
`getKnownTemplates` globs from the project root with `**/node_modules/.marko/**` in the pattern set — which forces the walker into every package tree — and fast-glob follows symlinks by default. pnpm layouts link `node_modules` as a **cyclic symlink graph**, so an optimized build's discovery walk never terminates and exhausts the heap (reproduced on a pnpm app: fatal OOM at 4 GiB and 8 GiB alike; CPU profile was ~95% `getdents`/`open` under `@nodelib/fs.walk`).

With `followSymbolicLinks: false` the same build completes in 2.6s. Generated templates under `node_modules/.marko` are still found (that directory is real, not a link); the only newly-missed case is `.marko` files inside symlinked packages, which previously OOM'd rather than being found anyway.