### PR TITLE
fix: compile templates whose id carries an unknown query

### DIFF
--- a/.changeset/compile-templates-with-unknown-queries.md
+++ b/.changeset/compile-templates-with-unknown-queries.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Compile `.marko` modules whose id carries an unrecognized query, such as the marker `@vitest/coverage-*` appends when it pulls in files no test imported, which previously reached the coverage instrumenter as uncompiled Marko source. Queries that change what the module is (`?raw`, `?url`, `?inline`, ...) are still left for vite to serve.

--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -1,3 +1,9 @@
 # Developer Experience
 
 Friction in builds, tests, tooling, or repo workflows. Format and rules: [README.md](README.md).
+
+## Dev server `close()` never settles once a fixture request re-triggers dep optimization
+
+`src/__tests__/query.test.ts` › `describe("templates with a query")` | 2026-07-24 | impact:low | effort:med
+
+Creating a `vite.createServer` over `src/__tests__/fixtures/browser-basic` with the plugin, transforming `/src/index.js` (or `/src/template.marko`) and then requesting any second id — `?raw`, `?url`, an unknown marker — leaves `await server.close()` pending forever, so a mocha `after` hook times out. It does not reproduce on a plugin-free project, nor with the plugin over a project that has no optimizable deps, so it needs the dep optimizer that the plugin's `optimizeDeps.include`/`entries` defaults set up; whether the stall is vite's or the plugin's is unresolved. `optimizeDeps: { noDiscovery: true, include: [] }` on the test server avoids it, which is what the query tests do. Re-verify by dropping that option from the server in `src/__tests__/query.test.ts`.

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -86,26 +86,32 @@ describe("templates with a query", () => {
     await server?.close();
   });
 
-  // The hmr client keys the module by the requested url; a transparent query
-  // must leave everything else identical to the plain request.
   const transform = async (id: string) =>
-    (await server.environments.client.transformRequest(id))?.code.replaceAll(
-      JSON.stringify(id),
-      JSON.stringify(TEMPLATE),
-    );
+    (await server.environments.client.transformRequest(id))?.code;
+
+  // Vite prepends a cjs interop preamble whose consts are ordered
+  // nondeterministically, so a transparent query is checked against the
+  // compiled template that follows it.
+  const compiledTemplate = (code: string | undefined) => {
+    const start = code?.indexOf("const _marko_componentType") ?? -1;
+    assert.notEqual(start, -1, `expected a compiled template, got:\n${code}`);
+    return code!.slice(start);
+  };
 
   it("compiles a template requested with an unknown marker query", async () => {
     // `@vitest/coverage-*` re-requests uncovered files with a marker like this.
     assert.equal(
-      await transform(`${TEMPLATE}?cache=123&vitest-uncovered-coverage=true`),
-      await transform(TEMPLATE),
+      compiledTemplate(
+        await transform(`${TEMPLATE}?cache=123&vitest-uncovered-coverage=true`),
+      ),
+      compiledTemplate(await transform(TEMPLATE)),
     );
   });
 
   it("compiles a template requested with a cache busting query", async () => {
     assert.equal(
-      await transform(`${TEMPLATE}?v=abc`),
-      await transform(TEMPLATE),
+      compiledTemplate(await transform(`${TEMPLATE}?v=abc`)),
+      compiledTemplate(await transform(TEMPLATE)),
     );
   });
 

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -1,0 +1,127 @@
+import assert from "assert";
+import path from "path";
+import url from "url";
+import type * as viteNamespace from "vite";
+
+import markoPlugin from "..";
+import { cleanUrl, hasOpaqueQuery } from "../query";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const FIXTURE_DIR = path.join(__dirname, "fixtures/browser-basic");
+const TEMPLATE = "/src/template.marko";
+
+describe("cleanUrl", () => {
+  const cases: [id: string, expected: string][] = [
+    ["/src/template.marko", "/src/template.marko"],
+    ["/src/template.marko?cache=123", "/src/template.marko"],
+    ["/src/template.marko?v=abc", "/src/template.marko"],
+    ["/src/template.marko?t=123", "/src/template.marko"],
+    ["/src/template.marko?raw", "/src/template.marko"],
+    [
+      "/src/template.marko?cache=123&vitest-uncovered-coverage=true",
+      "/src/template.marko",
+    ],
+  ];
+
+  for (const [id, expected] of cases) {
+    it(`${id} -> ${expected}`, () => {
+      assert.equal(cleanUrl(id), expected);
+    });
+  }
+
+  it("never leaves a dangling separator", () => {
+    for (const [id] of cases) {
+      const cleaned = cleanUrl(id);
+      assert.ok(!/[?&]$/.test(cleaned), `${id} -> ${cleaned}`);
+      assert.ok(!cleaned.includes("?"), `${id} -> ${cleaned}`);
+    }
+  });
+});
+
+// `.marko` files are compiled when `cleanUrl(id)` names one and the query is
+// not opaque, so anything below that is not opaque is compiled.
+describe("hasOpaqueQuery", () => {
+  const cases: [id: string, expected: boolean][] = [
+    ["/src/template.marko", false],
+    ["/src/template.marko?cache=123", false],
+    ["/src/template.marko?v=abc", false],
+    ["/src/template.marko?t=123", false],
+    ["/src/template.marko?cache=123&vitest-uncovered-coverage=true", false],
+    ["/src/template.marko?raw", true],
+    ["/src/template.marko?url", true],
+    ["/src/template.marko?inline", true],
+    ["/src/template.marko?worker", true],
+    ["/src/template.marko?cache=123&raw", true],
+    ["/src/template.marko.html?html-proxy&index=0.js", true],
+    // `raw` only counts as its own query param.
+    ["/src/template.marko?rawr", false],
+    ["/src/template.marko?not-raw", false],
+  ];
+
+  for (const [id, expected] of cases) {
+    it(`${id} -> ${expected}`, () => {
+      assert.equal(hasOpaqueQuery(id), expected);
+    });
+  }
+});
+
+describe("templates with a query", () => {
+  let vite: typeof viteNamespace;
+  let server: viteNamespace.ViteDevServer;
+
+  before(async () => {
+    vite = await import("vite");
+    server = await vite.createServer({
+      root: FIXTURE_DIR,
+      logLevel: "error",
+      server: { middlewareMode: true, hmr: false, watch: null },
+      // Requesting the same file with and without a query re-triggers dep
+      // discovery, which leaves `server.close()` hanging.
+      optimizeDeps: { noDiscovery: true, include: [] },
+      plugins: [markoPlugin({ linked: false })],
+    });
+  });
+
+  after(async () => {
+    await server?.close();
+  });
+
+  // The hmr client keys the module by the requested url; a transparent query
+  // must leave everything else identical to the plain request.
+  const transform = async (id: string) =>
+    (await server.environments.client.transformRequest(id))?.code.replaceAll(
+      JSON.stringify(id),
+      JSON.stringify(TEMPLATE),
+    );
+
+  it("compiles a template requested with an unknown marker query", async () => {
+    // `@vitest/coverage-*` re-requests uncovered files with a marker like this.
+    assert.equal(
+      await transform(`${TEMPLATE}?cache=123&vitest-uncovered-coverage=true`),
+      await transform(TEMPLATE),
+    );
+  });
+
+  it("compiles a template requested with a cache busting query", async () => {
+    assert.equal(
+      await transform(`${TEMPLATE}?v=abc`),
+      await transform(TEMPLATE),
+    );
+  });
+
+  it("leaves ?raw as the template source", async () => {
+    const code = await transform(`${TEMPLATE}?raw`);
+    assert.ok(
+      code?.includes("<div#page>"),
+      `expected the template source, got:\n${code}`,
+    );
+  });
+
+  it("leaves ?url as the template url", async () => {
+    const code = await transform(`${TEMPLATE}?url`);
+    assert.ok(
+      code?.includes(JSON.stringify(TEMPLATE)),
+      `expected the template url, got:\n${code}`,
+    );
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {
   type LinkAssetsDocManifest,
 } from "./manifest-generator";
 import { normalizePath, POSIX_SEP, WINDOWS_SEP } from "./normalize-path";
+import { cleanUrl, hasOpaqueQuery } from "./query";
 import { ReadOncePersistedStore } from "./read-once-persisted-store";
 import relativeAssetsTransform from "./relative-assets-transform";
 import {
@@ -543,7 +544,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
                   // Let vite handle externals as it normally would.
                   if (external) return undefined;
                   return markoSideEffectImportIds.has(id) ||
-                    isSideEffectFile(stripViteQueries(id))
+                    isSideEffectFile(cleanUrl(id))
                     ? undefined
                     : false;
                 },
@@ -840,7 +841,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
           if (
             resolved &&
             !resolved.external &&
-            !isSideEffectFile(stripViteQueries(resolved.id))
+            !isSideEffectFile(cleanUrl(resolved.id))
           ) {
             markoSideEffectImportIds.add(resolved.id);
           }
@@ -860,7 +861,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
 
         if (importer) {
           const tagName = importTagReg.exec(importee)?.[1];
-          importer = stripViteQueries(importer);
+          importer = cleanUrl(importer);
 
           if (tagName) {
             const tagDef = compiler.taglib
@@ -928,10 +929,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
               : await this.resolve(importee, importer, resolveOpts);
 
           if (resolved) {
-            resolved.id = toMarkoFileId(
-              stripViteQueries(resolved.id),
-              importeeInfo,
-            );
+            resolved.id = toMarkoFileId(cleanUrl(resolved.id), importeeInfo);
           }
 
           return resolved;
@@ -956,7 +954,11 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
         return null;
       },
       async load(rawId) {
-        const id = stripViteQueries(rawId);
+        // `?raw`, `?url`, ... are vite's to serve: it must see the file as it
+        // is on disk, so the marko file behind the query is left alone.
+        if (hasOpaqueQuery(rawId)) return null;
+
+        const id = cleanUrl(rawId);
 
         switch (id) {
           case cjsInteropHelpersId:
@@ -1019,7 +1021,9 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
         return virtualFiles.get(id) || cachedSources.get(id) || null;
       },
       async transform(source, rawId) {
-        const id = stripViteQueries(rawId);
+        if (hasOpaqueQuery(rawId)) return null;
+
+        const id = cleanUrl(rawId);
         const info = getMarkoFileInfo(id);
         const isSSR = this.environment.name === "ssr";
         const isClientEntry = info?.kind === InternalFileKind.clientEntry;
@@ -1179,7 +1183,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
                     if (
                       resolved &&
                       !resolved.external &&
-                      !isSideEffectFile(stripViteQueries(resolved.id))
+                      !isSideEffectFile(cleanUrl(resolved.id))
                     ) {
                       markoSideEffectImportIds.add(resolved.id);
                     }
@@ -1658,17 +1662,6 @@ function isEmpty(obj: unknown) {
   }
 
   return true;
-}
-
-function stripViteQueries(id: string) {
-  const queryStart = id.indexOf("?");
-  if (queryStart === -1) return id;
-  const url = id.slice(0, queryStart);
-  const query = id
-    .slice(queryStart + 1)
-    .replace(/(?:^|[&])(?:cache|[vt])=[^&]+/g, "");
-  if (query) return `${url}?${query}`;
-  return url;
 }
 
 function getKnownTemplates(cwd: string) {

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,0 +1,18 @@
+// Vite (and anything built on it) tags module ids with queries: cache busters
+// (`?v=`, `?t=`), and one-off markers other tools bolt on. The file being
+// requested is always the path before the `?`.
+export function cleanUrl(id: string) {
+  const queryStart = id.indexOf("?");
+  return queryStart === -1 ? id : id.slice(0, queryStart);
+}
+
+// The queries below change what the module *is* instead of just tagging the
+// id, and vite serves them itself, so a `.marko` file carrying one must be left
+// uncompiled. Every other query is transparent.
+const opaqueQueryReg =
+  /(?:^|&)(?:raw|url|inline|no-inline|worker|sharedworker|worklet|html-proxy|direct)(?:[&=]|$)/;
+
+export function hasOpaqueQuery(id: string) {
+  const queryStart = id.indexOf("?");
+  return queryStart !== -1 && opaqueQueryReg.test(id.slice(queryStart + 1));
+}


### PR DESCRIPTION
`stripViteQueries` stripped an allowlist of three params (`cache`, `v`, `t`), so any other query left the id failing `isMarkoFile` and the template flowed through `load`/`transform` uncompiled. `@vitest/coverage-istanbul` re-requests uncovered files as `foo.marko?cache=…&vitest-uncovered-coverage=true`, so raw Marko source reached its babel instrumenter and `vitest run --coverage` died with a `SyntaxError` on any `.marko` file no test imported.

Splits the two things that function conflated: `cleanUrl` answers "what file is this" (and no longer emits the malformed `?&…` ids the old strip left behind), `hasOpaqueQuery` answers "may Marko compile it" for the vite queries that change what the module *is*. `load` and `transform` bail on the latter, which is what keeps `?raw` and `?url` working — they previously worked only as a side effect of the id failing the `.marko` check.

Note this inverts a denylist into an allowlist: an unknown *content-changing* query from a third-party plugin would now be compiled rather than skipped. That looks like the right default (cache-busters and markers vastly outnumber them, and vite's set is stable), but it's a judgement call worth a second opinion.

Verified against a real vitest 4.1.10 + `@vitest/coverage-istanbul` project with an un-imported `.marko`: crashes before, passes after with the file reporting real coverage numbers. Covered here by unit cases on the id helpers plus dev-server tests that a marker-queried request transforms identically to the plain one while `?raw`/`?url` still return source text and url.