### PR TITLE
fix: don't assume a `test` section when vite runs in test mode

### DIFF
--- a/.changeset/vitest-without-test-config.md
+++ b/.changeset/vitest-without-test-config.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Fix a crash when vitest resolves a vite config that has no `test` section. The plugin read `config.test.environment` unguarded in test mode, so simply having `@marko/vite` installed made `vitest run` fail before any test loaded.

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,9 +284,11 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
         hasBuildApp = !!config.builder?.buildApp;
 
         if (isTest) {
+          // vitest resolves a plain vite config too, which carries no `test`
+          // section, so this cannot assume one is present.
           const { test } = config as any;
           linked = false;
-          if ((test.environment as string | undefined)?.includes("dom")) {
+          if ((test?.environment as string | undefined)?.includes("dom")) {
             config.resolve ??= {};
             config.resolve.conditions ??= [];
             config.resolve.conditions.push("browser");


### PR DESCRIPTION
In test mode the plugin destructured `config.test` and read `test.environment` without guarding it. vitest resolves a plain `vite.config.ts` — which has no `test` section — so merely having `@marko/vite` installed made `vitest run` fail before a single test loaded:

```
TypeError: Cannot read properties of undefined (reading 'environment')
    at BasicMinimalPluginContext.config (@marko/vite/dist/index.mjs)
```

That pushes consumers into maintaining a separate `vitest.config.ts` purely to keep the site plugins out of the way, which is what surfaced this on markojs.com.

The dom-environment branch is unchanged when a `test` section is present; `test.execArgv` is only touched inside that branch, where `test` is known to exist.

Verified against the real failure: with a locally built `dist` swapped into markojs.com's `node_modules`, `vitest run --config vite.config.ts` goes from the TypeError above to `Test Files 1 passed / Tests 6 passed`.