### PR TITLE
fix: keep zero-runtime stylesheet modules out of client treeshaking

### DIFF
--- a/.changeset/css-script-side-effects.md
+++ b/.changeset/css-script-side-effects.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Treat zero-runtime stylesheet modules (`*.css.ts`, `*.css.js`) as having side effects so their styles are still emitted when only server-rendered markup uses them.

--- a/src/__tests__/fixtures/browser-side-effects/__snapshots__/build.expected.md
+++ b/src/__tests__/fixtures/browser-side-effects/__snapshots__/build.expected.md
@@ -12,7 +12,7 @@
   <div
     id="loaded"
   >
-    loaded: explicit-side-effect, nested-side-effect, side-effect-lib/register
+    loaded: css-js-stylesheet, explicit-side-effect, nested-side-effect, side-effect-lib/register
   </div>
 </div>
 ```

--- a/src/__tests__/fixtures/browser-side-effects/__snapshots__/dev.expected.md
+++ b/src/__tests__/fixtures/browser-side-effects/__snapshots__/dev.expected.md
@@ -12,7 +12,7 @@
   <div
     id="loaded"
   >
-    loaded: explicit-side-effect, impure-lib, nested-side-effect, server-only, side-effect-lib/register
+    loaded: css-js-stylesheet, explicit-side-effect, impure-lib, nested-side-effect, server-only, side-effect-lib/register
   </div>
 </div>
 ```

--- a/src/__tests__/fixtures/browser-side-effects/src/server-styles.css.js
+++ b/src/__tests__/fixtures/browser-side-effects/src/server-styles.css.js
@@ -1,0 +1,9 @@
+import { loaded } from "./tracker.js";
+
+// A zero-runtime stylesheet module. Compiling it is what emits the stylesheet,
+// so it must reach the client build even though its export is server-only.
+loaded.push("css-js-stylesheet");
+
+export function serverOnlyStyle() {
+  return "server-only-style";
+}

--- a/src/__tests__/fixtures/browser-side-effects/src/template.marko
+++ b/src/__tests__/fixtures/browser-side-effects/src/template.marko
@@ -1,5 +1,6 @@
 import { onlyServer } from "./server-only.js";
 import { impureServerOnly } from "impure-lib";
+import { serverOnlyStyle } from "./server-styles.css.js";
 import { shared } from "./shared.js";
 import { loaded } from "./tracker.js";
 import "./explicit-side-effect.js";
@@ -8,9 +9,12 @@ import "./styles.css";
 
 // `onlyServer`/`impureServerOnly` are used only in a server block, so they (and
 // `impure-lib`, which has no `sideEffects` field) tree-shake out of the client.
+// `serverOnlyStyle` is used the same way, but its `.css.js` module is a
+// stylesheet, so it is kept regardless.
 server {
   onlyServer();
   impureServerOnly();
+  serverOnlyStyle();
 }
 
 <div.marko-side-effects>

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,13 +110,12 @@ const virtualFilesForTemplate = new Map<string, Set<string>>();
 const virtualFilesResetForTemplate = new Map<string, number>();
 const ssrTransformCache = new Map<string, string>();
 const importTagReg = /^<([^>]+)>$/;
-// Styles Vite's `assetsInclude` skips (it handles css/preprocessors itself).
+// Styles Vite's `assetsInclude` skips (it handles css/preprocessors itself),
+// plus zero-runtime stylesheet modules (`*.css.ts`, vanilla-extract and
+// friends) -- those look pure, exporting only class name strings, but compiling
+// one is what emits its stylesheet.
 const styleImportReg =
-  /\.(?:css|less|s[ac]ss|styl(?:us)?|pcss|postcss)(?:\?|$)/i;
-// Zero-runtime CSS-in-JS stylesheets (vanilla-extract and friends). The module
-// looks pure -- it only exports class name strings -- but building it is what
-// emits the stylesheet, so it must not be treeshaken out of the client.
-const styleScriptImportReg = /\.css\.[cm]?[jt]s(?:\?|$)/i;
+  /\.(?:css(?:\.[cm]?[jt]s)?|less|s[ac]ss|styl(?:us)?|pcss|postcss)(?:\?|$)/i;
 const optionalWatchFileReg =
   /[\\/](?:([^\\/]+)\.)?(?:marko-tag.json|(?:style|component|component-browser)\.\w+)$/;
 const noClientAssetsRuntimeId = "\0no_client_bundles.mjs";
@@ -268,10 +267,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
   // Kept purely by path: a `.marko` file, a style (or stylesheet module), or a
   // Vite asset.
   const isSideEffectFile = (file: string) =>
-    isMarkoFile(file) ||
-    styleImportReg.test(file) ||
-    styleScriptImportReg.test(file) ||
-    viteAssetsInclude(file);
+    isMarkoFile(file) || styleImportReg.test(file) || viteAssetsInclude(file);
 
   return [
     {

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,10 @@ const importTagReg = /^<([^>]+)>$/;
 // Styles Vite's `assetsInclude` skips (it handles css/preprocessors itself).
 const styleImportReg =
   /\.(?:css|less|s[ac]ss|styl(?:us)?|pcss|postcss)(?:\?|$)/i;
+// Zero-runtime CSS-in-JS stylesheets (vanilla-extract and friends). The module
+// looks pure -- it only exports class name strings -- but building it is what
+// emits the stylesheet, so it must not be treeshaken out of the client.
+const styleScriptImportReg = /\.css\.[cm]?[jt]s(?:\?|$)/i;
 const optionalWatchFileReg =
   /[\\/](?:([^\\/]+)\.)?(?:marko-tag.json|(?:style|component|component-browser)\.\w+)$/;
 const noClientAssetsRuntimeId = "\0no_client_bundles.mjs";
@@ -261,9 +265,13 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
     `vite-marko${runtimeId ? `-${runtimeId}` : ""}`,
   );
   const isTagsApi = (api: undefined | string) => api === "tags";
-  // Kept purely by path: a `.marko` file, a style, or a Vite asset.
+  // Kept purely by path: a `.marko` file, a style (or stylesheet module), or a
+  // Vite asset.
   const isSideEffectFile = (file: string) =>
-    isMarkoFile(file) || styleImportReg.test(file) || viteAssetsInclude(file);
+    isMarkoFile(file) ||
+    styleImportReg.test(file) ||
+    styleScriptImportReg.test(file) ||
+    viteAssetsInclude(file);
 
   return [
     {


### PR DESCRIPTION
The client build defaults every module to side-effect free, keeping only `.marko` files, styles, assets, and bare-import subgraphs. A zero-runtime stylesheet module (`*.css.ts` / `*.css.js`, as used by vanilla-extract) looks pure — it only exports class name strings — so when nothing in the client bundle references those exports, the module is dropped and its stylesheet is silently never emitted. The page renders unstyled with no build warning.

This treats those modules as side-effectful by path, alongside styles and assets.