### PR TITLE
Split css module class map and stylesheet in the client build

### DIFF
--- a/.changeset/empty-css-carrier-chunk.md
+++ b/.changeset/empty-css-carrier-chunk.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Remove client chunks left holding only `import` statements once their css modules' stylesheets are extracted, instead of preloading them on every page that shares the stylesheet.

--- a/.changeset/empty-css-module-chunk.md
+++ b/.changeset/empty-css-module-chunk.md
@@ -1,0 +1,5 @@
+---
+"@marko/vite": patch
+---
+
+Stop emitting an empty JS chunk (and injecting a script tag for it) for css modules whose class name map is only read on the server. In the client build a css module import now resolves to a virtual that re-exports the class map from vite's `?transform-only` view of the module (tree shaken whenever the map goes unused) and loads the compiled css as a plain stylesheet, replacing the previous blanket `no-treeshake` marking. With `build.modulePreload.polyfill` disabled, a page whose only client asset is a stylesheet now ships no JS at all.

--- a/src/__tests__/fixtures/isomorphic-bundle-splitting/__snapshots__/build.expected.md
+++ b/src/__tests__/fixtures/isomorphic-bundle-splitting/__snapshots__/build.expected.md
@@ -7,11 +7,6 @@
   src="/assets/class-[hash].marko-[hash].js"
   type="module"
 />
-<link
-  crossorigin=""
-  href="/assets/[hash].js"
-  rel="modulepreload"
-/>
 <div
   class="clickable"
 >

--- a/src/__tests__/fixtures/isomorphic-css-carrier-chunk/README.md
+++ b/src/__tests__/fixtures/isomorphic-css-carrier-chunk/README.md
@@ -1,0 +1,7 @@
+Three pages share a client entry (`layout.marko`'s `client import`) and a
+layout stylesheet. `tag-a` (pages `/` and `/two`) renders `tag-b` (all three
+pages), each with its own css module. `tag-b`'s css rides the shared chunk with
+the layout's, but `tag-a`'s page set differs, so its stylesheet gets a chunk of
+its own; once the css is extracted that chunk is only an `import` of the shared
+chunk. The snapshot for `/` asserts no such script is preloaded. `/three` is
+never visited: it exists only to split the page sets.

--- a/src/__tests__/fixtures/isomorphic-css-carrier-chunk/__snapshots__/build.expected.md
+++ b/src/__tests__/fixtures/isomorphic-css-carrier-chunk/__snapshots__/build.expected.md
@@ -1,0 +1,22 @@
+# Loading
+
+```html
+<div
+  class="_box_scoped"
+>
+  <div
+    class="_box_scoped"
+  >
+    one
+  </div>
+</div>
+```
+
+# Step 0
+const app=browser.window.document.getElementById("app");for(const el of browser.window.document.querySelectorAll("link[rel=stylesheet], link[rel=modulepreload], script[src]")){app.append(`[${el.tagName.toLowerCase()
+
+```diff
+-</div>+</div>
+[link: /assets/layout-[hash].css][link: /assets/tag-[hash].css][script: /assets/template-[hash].marko-[hash].js][link: /assets/[hash].js]
+```
+

--- a/src/__tests__/fixtures/isomorphic-css-carrier-chunk/__snapshots__/dev.expected.md
+++ b/src/__tests__/fixtures/isomorphic-css-carrier-chunk/__snapshots__/dev.expected.md
@@ -1,0 +1,22 @@
+# Loading
+
+```html
+<div
+  class="_box_scoped"
+>
+  <div
+    class="_box_scoped"
+  >
+    one
+  </div>
+</div>
+```
+
+# Step 0
+const app=browser.window.document.getElementById("app");for(const el of browser.window.document.querySelectorAll("link[rel=stylesheet], link[rel=modulepreload], script[src]")){app.append(`[${el.tagName.toLowerCase()
+
+```diff
+-</div>+</div>
+[script: /@vite/client][script: /src/template-[hash].client-[hash].marko]
+```
+

--- a/src/__tests__/fixtures/isomorphic-css-carrier-chunk/dev-server.mjs
+++ b/src/__tests__/fixtures/isomorphic-css-carrier-chunk/dev-server.mjs
@@ -1,0 +1,43 @@
+// In dev we'll start a Vite dev server in middleware mode,
+// and forward requests to our http request handler.
+
+import { createRequire } from "module";
+import path from "path";
+import url from "url";
+import { createServer } from "vite";
+
+// change to import once marko-vite is updated to ESM
+const markoPlugin = createRequire(import.meta.url)("../../..").default;
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+const devServer = await createServer({
+  root: __dirname,
+  appType: "custom",
+  logLevel: "warn",
+  plugins: [markoPlugin()],
+  optimizeDeps: { force: true },
+  server: {
+    ws: false,
+    hmr: false,
+    middlewareMode: true,
+    watch: {
+      ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
+    },
+  },
+  build: {
+    assetsInlineLimit: 0,
+  },
+});
+
+export default devServer.middlewares.use(async (req, res, next) => {
+  try {
+    const { handler } = await devServer.ssrLoadModule(
+      path.join(__dirname, "./src/index.js")
+    );
+    await handler(req, res, next);
+  } catch (err) {
+    devServer.ssrFixStacktrace(err);
+    return next(err);
+  }
+});

--- a/src/__tests__/fixtures/isomorphic-css-carrier-chunk/server.mjs
+++ b/src/__tests__/fixtures/isomorphic-css-carrier-chunk/server.mjs
@@ -1,0 +1,16 @@
+// In production, simply start up the http server.
+import { createServer } from "http";
+import path from 'path'
+import serve from "serve-handler";
+import url from 'url';
+
+import { handler } from "./dist/index.mjs";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const serveOpts = { public: path.resolve(__dirname, "dist") };
+
+export default createServer(async (req, res) => {
+  await handler(req, res);
+  if (res.headersSent) return;
+  await serve(req, res, serveOpts);
+});

--- a/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/client/thing.js
+++ b/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/client/thing.js
@@ -1,0 +1,1 @@
+console.log("the only browser code on the site");

--- a/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/index.js
+++ b/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/index.js
@@ -1,0 +1,19 @@
+import templateOne from "./template-one.marko";
+import templateThree from "./template-three.marko";
+import templateTwo from "./template-two.marko";
+
+export function handler(req, res) {
+  const template =
+    req.url === "/"
+      ? templateOne
+      : req.url === "/two"
+        ? templateTwo
+        : req.url === "/three"
+          ? templateThree
+          : null;
+  if (template) {
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    template.render({}).pipe(res);
+  }
+}

--- a/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/layout.css
+++ b/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/layout.css
@@ -1,0 +1,1 @@
+body { margin: 0; }

--- a/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/tags/layout.marko
+++ b/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/tags/layout.marko
@@ -1,0 +1,12 @@
+client import "../client/thing.js";
+import "../layout.css";
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>repro</title>
+</head>
+<body>
+  <${input.content}/>
+</body>
+</html>

--- a/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/tags/tag-a.marko
+++ b/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/tags/tag-a.marko
@@ -1,0 +1,3 @@
+import styles from "./tag-a.module.css";
+
+<div class=styles.box><tag-b><${input.content}/></tag-b></div>

--- a/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/tags/tag-a.module.css
+++ b/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/tags/tag-a.module.css
@@ -1,0 +1,1 @@
+.box { color: rebeccapurple; }

--- a/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/tags/tag-b.marko
+++ b/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/tags/tag-b.marko
@@ -1,0 +1,3 @@
+import styles from "./tag-b.module.css";
+
+<div class=styles.box><${input.content}/></div>

--- a/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/tags/tag-b.module.css
+++ b/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/tags/tag-b.module.css
@@ -1,0 +1,1 @@
+.box { color: rebeccapurple; }

--- a/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/template-one.marko
+++ b/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/template-one.marko
@@ -1,0 +1,5 @@
+<layout>
+  <div#app>
+    <tag-a>one</tag-a>
+  </div>
+</layout>

--- a/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/template-three.marko
+++ b/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/template-three.marko
@@ -1,0 +1,5 @@
+<layout>
+  <div#app>
+    <tag-b>three</tag-b>
+  </div>
+</layout>

--- a/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/template-two.marko
+++ b/src/__tests__/fixtures/isomorphic-css-carrier-chunk/src/template-two.marko
@@ -1,0 +1,5 @@
+<layout>
+  <div#app>
+    <tag-a>two</tag-a>
+  </div>
+</layout>

--- a/src/__tests__/fixtures/isomorphic-css-carrier-chunk/test.config.ts
+++ b/src/__tests__/fixtures/isomorphic-css-carrier-chunk/test.config.ts
@@ -1,0 +1,14 @@
+export const ssr = true;
+export function steps() {
+  // Reflect the injected assets into #app so the snapshot records which
+  // scripts a page loads: modulepreloads included, since a chunk that only
+  // carries a stylesheet is never a <script>, only a preload the entry imports.
+  const app = browser.window.document.getElementById("app")!;
+  for (const el of browser.window.document.querySelectorAll(
+    "link[rel=stylesheet], link[rel=modulepreload], script[src]",
+  )) {
+    app.append(
+      `[${el.tagName.toLowerCase()}: ${el.getAttribute("href") || el.getAttribute("src")}]`,
+    );
+  }
+}

--- a/src/__tests__/fixtures/isomorphic-css-carrier-chunk/vite.config.mjs
+++ b/src/__tests__/fixtures/isomorphic-css-carrier-chunk/vite.config.mjs
@@ -1,0 +1,9 @@
+export default {
+  css: {
+    modules: {
+      // The default scoped name hashes the file path, which differs across
+      // platforms (windows path separators); pin it so snapshots are stable.
+      generateScopedName: "_[local]_scoped",
+    },
+  },
+};

--- a/src/__tests__/fixtures/isomorphic-link-assets/__snapshots__/build.expected.md
+++ b/src/__tests__/fixtures/isomorphic-link-assets/__snapshots__/build.expected.md
@@ -16,6 +16,11 @@
   src="/assets/lazy.load-[hash].marko-[hash].js"
   type="module"
 />
+<link
+  crossorigin=""
+  href="/assets/[hash].js"
+  rel="modulepreload"
+/>
 <button
   id="lazy-clickable"
 >

--- a/src/__tests__/fixtures/isomorphic-shared-css-module/__snapshots__/build.expected.md
+++ b/src/__tests__/fixtures/isomorphic-shared-css-module/__snapshots__/build.expected.md
@@ -1,0 +1,18 @@
+# Loading
+
+```html
+<div
+  class="_thing_1n3is_1"
+>
+  first page
+</div>
+```
+
+# Step 0
+const app=browser.window.document.getElementById("app");for(const el of browser.window.document.querySelectorAll("link[rel=stylesheet], script[src]")){app.append(`[${el.tagName.toLowerCase()
+
+```diff
+-</div>+</div>
+[link: /assets/styled-[hash].css][script: /assets/[hash].js]
+```
+

--- a/src/__tests__/fixtures/isomorphic-shared-css-module/__snapshots__/build.expected.md
+++ b/src/__tests__/fixtures/isomorphic-shared-css-module/__snapshots__/build.expected.md
@@ -2,7 +2,7 @@
 
 ```html
 <div
-  class="_thing_1n3is_1"
+  class="_thing_scoped"
 >
   first page
 </div>
@@ -13,6 +13,6 @@ const app=browser.window.document.getElementById("app");for(const el of browser.
 
 ```diff
 -</div>+</div>
-[link: /assets/styled-[hash].css][script: /assets/[hash].js]
+[link: /assets/styled-[hash].module-[hash].css]
 ```
 

--- a/src/__tests__/fixtures/isomorphic-shared-css-module/__snapshots__/dev.expected.md
+++ b/src/__tests__/fixtures/isomorphic-shared-css-module/__snapshots__/dev.expected.md
@@ -1,0 +1,18 @@
+# Loading
+
+```html
+<div
+  class="_thing_1n3is_1"
+>
+  first page
+</div>
+```
+
+# Step 0
+const app=browser.window.document.getElementById("app");for(const el of browser.window.document.querySelectorAll("link[rel=stylesheet], script[src]")){app.append(`[${el.tagName.toLowerCase()
+
+```diff
+-</div>+</div>
+[script: /@vite/client][script: /src/template-[hash].client-[hash].marko]
+```
+

--- a/src/__tests__/fixtures/isomorphic-shared-css-module/__snapshots__/dev.expected.md
+++ b/src/__tests__/fixtures/isomorphic-shared-css-module/__snapshots__/dev.expected.md
@@ -2,7 +2,7 @@
 
 ```html
 <div
-  class="_thing_1n3is_1"
+  class="_thing_scoped"
 >
   first page
 </div>

--- a/src/__tests__/fixtures/isomorphic-shared-css-module/dev-server.mjs
+++ b/src/__tests__/fixtures/isomorphic-shared-css-module/dev-server.mjs
@@ -1,0 +1,43 @@
+// In dev we'll start a Vite dev server in middleware mode,
+// and forward requests to our http request handler.
+
+import { createRequire } from "module";
+import path from "path";
+import url from "url";
+import { createServer } from "vite";
+
+// change to import once marko-vite is updated to ESM
+const markoPlugin = createRequire(import.meta.url)("../../..").default;
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+const devServer = await createServer({
+  root: __dirname,
+  appType: "custom",
+  logLevel: "warn",
+  plugins: [markoPlugin()],
+  optimizeDeps: { force: true },
+  server: {
+    ws: false,
+    hmr: false,
+    middlewareMode: true,
+    watch: {
+      ignored: ["**/node_modules/**", "**/dist/**", "**/__snapshots__/**"],
+    },
+  },
+  build: {
+    assetsInlineLimit: 0,
+  },
+});
+
+export default devServer.middlewares.use(async (req, res, next) => {
+  try {
+    const { handler } = await devServer.ssrLoadModule(
+      path.join(__dirname, "./src/index.js")
+    );
+    await handler(req, res, next);
+  } catch (err) {
+    devServer.ssrFixStacktrace(err);
+    return next(err);
+  }
+});

--- a/src/__tests__/fixtures/isomorphic-shared-css-module/server.mjs
+++ b/src/__tests__/fixtures/isomorphic-shared-css-module/server.mjs
@@ -1,0 +1,16 @@
+// In production, simply start up the http server.
+import { createServer } from "http";
+import path from 'path'
+import serve from "serve-handler";
+import url from 'url';
+
+import { handler } from "./dist/index.mjs";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const serveOpts = { public: path.resolve(__dirname, "dist") };
+
+export default createServer(async (req, res) => {
+  await handler(req, res);
+  if (res.headersSent) return;
+  await serve(req, res, serveOpts);
+});

--- a/src/__tests__/fixtures/isomorphic-shared-css-module/src/index.js
+++ b/src/__tests__/fixtures/isomorphic-shared-css-module/src/index.js
@@ -1,0 +1,12 @@
+import templateA from "./template-a.marko";
+import templateB from "./template-b.marko";
+
+export function handler(req, res) {
+  const template =
+    req.url === "/" ? templateA : req.url === "/second" ? templateB : null;
+  if (template) {
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    template.render({}).pipe(res);
+  }
+}

--- a/src/__tests__/fixtures/isomorphic-shared-css-module/src/tags/layout.marko
+++ b/src/__tests__/fixtures/isomorphic-shared-css-module/src/tags/layout.marko
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Hello World</title>
+</head>
+<body>
+  <${input.content}/>
+</body>
+</html>

--- a/src/__tests__/fixtures/isomorphic-shared-css-module/src/tags/styled-thing.marko
+++ b/src/__tests__/fixtures/isomorphic-shared-css-module/src/tags/styled-thing.marko
@@ -1,0 +1,5 @@
+import styles from "./styled-thing.module.css";
+
+<div class=styles.thing>
+  <${input.content}/>
+</div>

--- a/src/__tests__/fixtures/isomorphic-shared-css-module/src/tags/styled-thing.module.css
+++ b/src/__tests__/fixtures/isomorphic-shared-css-module/src/tags/styled-thing.module.css
@@ -1,0 +1,3 @@
+.thing {
+  color: rebeccapurple;
+}

--- a/src/__tests__/fixtures/isomorphic-shared-css-module/src/template-a.marko
+++ b/src/__tests__/fixtures/isomorphic-shared-css-module/src/template-a.marko
@@ -1,0 +1,5 @@
+<layout>
+  <div#app>
+    <styled-thing>first page</styled-thing>
+  </div>
+</layout>

--- a/src/__tests__/fixtures/isomorphic-shared-css-module/src/template-b.marko
+++ b/src/__tests__/fixtures/isomorphic-shared-css-module/src/template-b.marko
@@ -1,0 +1,5 @@
+<layout>
+  <div#app>
+    <styled-thing>second page</styled-thing>
+  </div>
+</layout>

--- a/src/__tests__/fixtures/isomorphic-shared-css-module/test.config.ts
+++ b/src/__tests__/fixtures/isomorphic-shared-css-module/test.config.ts
@@ -1,0 +1,13 @@
+export const ssr = true;
+export function steps() {
+  // Reflect the injected assets into #app so the snapshot records whether a
+  // script was emitted for a page whose only shared module is a stylesheet.
+  const app = browser.window.document.getElementById("app")!;
+  for (const el of browser.window.document.querySelectorAll(
+    "link[rel=stylesheet], script[src]",
+  )) {
+    app.append(
+      `[${el.tagName.toLowerCase()}: ${el.getAttribute("href") || el.getAttribute("src")}]`,
+    );
+  }
+}

--- a/src/__tests__/fixtures/isomorphic-shared-css-module/vite.config.mjs
+++ b/src/__tests__/fixtures/isomorphic-shared-css-module/vite.config.mjs
@@ -1,0 +1,9 @@
+export default {
+  css: {
+    modules: {
+      // The default scoped name hashes the file path, which differs across
+      // platforms (windows path separators); pin it so snapshots are stable.
+      generateScopedName: "_[local]_scoped",
+    },
+  },
+};

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -113,6 +113,7 @@ for (const fixture of fs.readdirSync(FIXTURES)) {
             minify: false,
             assetsInlineLimit: 0,
             emptyOutDir: false, // Avoid server / client deleting files from each other.
+            modulePreload: { polyfill: false }, // Lets stylesheet-only pages ship no JS, which css module fixtures assert on.
           },
         });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1349,11 +1349,29 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
           meta: { markoAPI: meta.api },
         };
       },
-      generateBundle(_outputOptions, bundle) {
-        // Runs from the `pre` plugin so the html and manifest plugins that
-        // follow never see the chunks dropped here.
-        if (linked && this.environment.name !== "ssr") {
-          removeEmptyChunks(bundle);
+      renderChunk(code, chunk, _opts, meta) {
+        // A css module's stylesheet is a side effect module, so a group of
+        // them shared by some pages but not others gets its own chunk. Once
+        // the css is extracted only the `import "./dep.js"` lines that order
+        // it after its dependencies are left, and every page preloads a script
+        // that does nothing. Vite's pure css pass drops such a chunk (folding
+        // its stylesheets into each importer) only when its code is entirely
+        // empty, so blank it when the imports are redundant: severing them is
+        // safe once every importer already imports the same chunks itself.
+        if (
+          linked &&
+          this.environment.name !== "ssr" &&
+          !chunk.isEntry &&
+          !chunk.isDynamicEntry &&
+          code.trim() &&
+          !code.replace(importStatementReg, "").trim() &&
+          Object.values(meta.chunks).every(
+            (importer) =>
+              !importer.imports.includes(chunk.fileName) ||
+              chunk.imports.every((dep) => importer.imports.includes(dep)),
+          )
+        ) {
+          return { code: "", map: null };
         }
       },
     },
@@ -1530,78 +1548,6 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
 
 function isMarkoFile(id: string) {
   return id.endsWith(markoExt);
-}
-
-/**
- * Drops chunks that carry nothing but a stylesheet.
- *
- * A css module's stylesheet is a side effect module, so a group of them that
- * is shared by some pages but not others gets its own chunk. Once the css is
- * extracted the chunk is left with the bare `import "./other.js"` lines that
- * order it after its dependencies, which vite's own pure-css pass does not
- * recognise (it requires an entirely empty chunk), so every page shipped a
- * modulepreload for a script that does nothing. Each importer takes over the
- * chunk's imports (in place, so side effect order holds) and its stylesheets.
- */
-function removeEmptyChunks(bundle: vite.Rollup.OutputBundle) {
-  const chunks = Object.values(bundle).filter(
-    (chunk) => chunk.type === "chunk",
-  );
-  const empty = new Map<string, vite.Rollup.OutputChunk>();
-  for (const chunk of chunks) {
-    if (
-      !chunk.isEntry &&
-      !chunk.isDynamicEntry &&
-      // Nothing but imports (a chunk with no code at all is left to vite).
-      chunk.code.trim() &&
-      !chunk.code.replace(importStatementReg, "").trim()
-    ) {
-      empty.set(chunk.fileName, chunk);
-    }
-  }
-
-  if (!empty.size) return;
-
-  for (const chunk of chunks) {
-    if (empty.has(chunk.fileName)) continue;
-    const dir = path.posix.dirname(chunk.fileName);
-    const seen = new Set(chunk.imports);
-    chunk.code = chunk.code.replace(importStatementReg, (match, spec) => {
-      const dropped = empty.get(path.posix.join(dir, spec));
-      if (!dropped) return match;
-      const hoisted: string[] = [];
-      const visit = (dropped: vite.Rollup.OutputChunk) => {
-        if (dropped.viteMetadata && chunk.viteMetadata) {
-          for (const css of dropped.viteMetadata.importedCss) {
-            chunk.viteMetadata.importedCss.add(css);
-          }
-          for (const asset of dropped.viteMetadata.importedAssets) {
-            chunk.viteMetadata.importedAssets.add(asset);
-          }
-        }
-        for (const fileName of dropped.imports) {
-          const nested = empty.get(fileName);
-          if (nested) visit(nested);
-          else if (!seen.has(fileName)) {
-            seen.add(fileName);
-            chunk.imports.push(fileName);
-            const rel = path.posix.relative(dir, fileName);
-            hoisted.push(
-              `import ${JSON.stringify(rel[0] === "." ? rel : "./" + rel)};`,
-            );
-          }
-        }
-      };
-      visit(dropped);
-      return hoisted.join("\n");
-    });
-    chunk.imports = chunk.imports.filter((fileName) => !empty.has(fileName));
-  }
-
-  for (const fileName of empty.keys()) {
-    delete bundle[fileName];
-    delete bundle[`${fileName}.map`];
-  }
 }
 
 const importStatementReg = /^\s*import\s*["']([^"']+)["'];?[ \t]*$/gm;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1349,6 +1349,13 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
           meta: { markoAPI: meta.api },
         };
       },
+      generateBundle(_outputOptions, bundle) {
+        // Runs from the `pre` plugin so the html and manifest plugins that
+        // follow never see the chunks dropped here.
+        if (linked && this.environment.name !== "ssr") {
+          removeEmptyChunks(bundle);
+        }
+      },
     },
     {
       name: "marko-vite:post",
@@ -1524,6 +1531,106 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
 function isMarkoFile(id: string) {
   return id.endsWith(markoExt);
 }
+
+/**
+ * Drops chunks that carry nothing but a stylesheet.
+ *
+ * A css module's stylesheet is a side effect module, so a group of them that
+ * is shared by some pages but not others gets its own chunk. Once the css is
+ * extracted the chunk is left with the bare `import "./other.js"` lines that
+ * order it after its dependencies, which vite's own pure-css pass does not
+ * recognise (it requires an entirely empty chunk), so every page shipped a
+ * modulepreload for a script that does nothing. Those imports are already
+ * satisfied by anything that imports the chunk, so it is removed and its
+ * importers pick up its imports and stylesheet metadata directly.
+ */
+function removeEmptyChunks(bundle: vite.Rollup.OutputBundle) {
+  const chunks = Object.values(bundle).filter(
+    (chunk) => chunk.type === "chunk",
+  );
+  const dynamicallyImported = new Set<string>();
+  for (const chunk of chunks) {
+    for (const fileName of chunk.dynamicImports) {
+      dynamicallyImported.add(fileName);
+    }
+  }
+
+  const removed = new Set<string>();
+  for (const chunk of chunks) {
+    if (
+      !chunk.isEntry &&
+      !chunk.isDynamicEntry &&
+      !chunk.exports.length &&
+      !dynamicallyImported.has(chunk.fileName) &&
+      // A chunk with no code at all is vite's pure css chunk to remove.
+      chunk.code.trim() &&
+      Object.values(chunk.modules).every((mod) => !mod.renderedLength) &&
+      !chunk.code.replace(emptyChunkImportReg, "").trim()
+    ) {
+      removed.add(chunk.fileName);
+    }
+  }
+
+  if (!removed.size) return;
+
+  for (const chunk of chunks) {
+    if (removed.has(chunk.fileName)) continue;
+    const seen = new Set(chunk.imports);
+    const imports: string[] = [];
+    const visit = (fileName: string) => {
+      if (removed.has(fileName)) {
+        const empty = bundle[fileName] as vite.Rollup.OutputChunk;
+        for (const imported of empty.imports) visit(imported);
+        if (empty.viteMetadata && chunk.viteMetadata) {
+          for (const css of empty.viteMetadata.importedCss) {
+            chunk.viteMetadata.importedCss.add(css);
+          }
+          for (const asset of empty.viteMetadata.importedAssets) {
+            chunk.viteMetadata.importedAssets.add(asset);
+          }
+        }
+      } else {
+        imports.push(fileName);
+      }
+    };
+
+    if (!chunk.imports.some((fileName) => removed.has(fileName))) continue;
+    for (const fileName of chunk.imports) visit(fileName);
+    chunk.imports = [...new Set(imports)];
+
+    const dir = path.posix.dirname(chunk.fileName);
+    const toSpecifier = (fileName: string) => {
+      const rel = path.posix.relative(dir, fileName);
+      return rel[0] === "." ? rel : "./" + rel;
+    };
+    chunk.code = chunk.code.replace(emptyChunkImportReg, (match, spec) => {
+      const fileName = path.posix.join(dir, spec);
+      if (!removed.has(fileName)) return match;
+      // Splice the dropped chunk's own imports in its place so the relative
+      // order of side effects is kept for anything not already imported.
+      const hoisted: string[] = [];
+      const visit = (fileName: string) => {
+        const empty = bundle[fileName] as vite.Rollup.OutputChunk;
+        for (const imported of empty.imports) {
+          if (removed.has(imported)) visit(imported);
+          else if (!seen.has(imported)) {
+            seen.add(imported);
+            hoisted.push(`import ${JSON.stringify(toSpecifier(imported))};`);
+          }
+        }
+      };
+      visit(fileName);
+      return hoisted.join("\n");
+    });
+  }
+
+  for (const fileName of removed) {
+    delete bundle[fileName];
+    delete bundle[`${fileName}.map`];
+  }
+}
+
+const emptyChunkImportReg = /^\s*import\s*["']([^"']+)["'];?[ \t]*$/gm;
 
 /**
  * Collects the css output files reachable from the chunk for the given

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,6 +119,10 @@ const styleImportReg =
 const optionalWatchFileReg =
   /[\\/](?:([^\\/]+)\.)?(?:marko-tag.json|(?:style|component|component-browser)\.\w+)$/;
 const noClientAssetsRuntimeId = "\0no_client_bundles.mjs";
+const cssModuleFacadePrefix = "\0marko-css-module:";
+const cssModuleStyleExt = ".marko-css-module.css";
+const cssModuleReg =
+  /\.module\.(?:css|less|s[ac]ss|styl(?:us)?|pcss|postcss)$/i;
 const markoExt = ".marko";
 const htmlExt = ".html";
 const clientEntryExt = ".client-entry.marko";
@@ -264,10 +268,13 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
     `vite-marko${runtimeId ? `-${runtimeId}` : ""}`,
   );
   const isTagsApi = (api: undefined | string) => api === "tags";
-  // Kept purely by path: a `.marko` file, a style (or stylesheet module), or a
-  // Vite asset.
+  // Kept purely by path: a `.marko` file, a style (or a css module's
+  // facade virtual), or a Vite asset.
   const isSideEffectFile = (file: string) =>
-    isMarkoFile(file) || styleImportReg.test(file) || viteAssetsInclude(file);
+    isMarkoFile(file) ||
+    styleImportReg.test(file) ||
+    file.startsWith(cssModuleFacadePrefix) ||
+    viteAssetsInclude(file);
 
   return [
     {
@@ -834,31 +841,32 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
         }
       },
       async resolveId(importee, importer, importOpts, ssr = importOpts.ssr) {
-        // An explicit bare `import "x"` only says *x* has side effects, but x's
-        // own side effects usually live in the modules it imports (eg terser
-        // installs `AST_Toplevel#resolve_defines` from a bare
-        // `import "./global-defs.js"`). Carry the marking downstream so the
-        // whole subgraph a template opted into keeps its side effects. This
-        // stops at `.marko`/style/asset ids, which are never added to the set,
-        // so a template's own imports stay shakeable.
-        if (
-          linked &&
-          isBuild &&
-          !ssr &&
-          importer &&
-          markoSideEffectImportIds.has(importer)
-        ) {
-          const resolved = await this.resolve(importee, importer, {
-            ...importOpts,
-            skipSelf: true,
-          });
+        if (linked && isBuild && !ssr && importer) {
+          // An explicit bare `import "x"` only says *x* has side effects, but
+          // x's own side effects usually live in the modules it imports (eg
+          // terser installs `AST_Toplevel#resolve_defines` from a bare
+          // `import "./global-defs.js"`). Carry the marking downstream so the
+          // whole subgraph a template opted into keeps its side effects. This
+          // stops at `.marko`/style/asset ids, which are never added to the
+          // set, so a template's own imports stay shakeable.
+          const isCssModule = cssModuleReg.test(importee);
 
-          if (
-            resolved &&
-            !resolved.external &&
-            !isSideEffectFile(cleanUrl(resolved.id))
-          ) {
-            markoSideEffectImportIds.add(resolved.id);
+          if (isCssModule || markoSideEffectImportIds.has(importer)) {
+            const resolved = await this.resolve(importee, importer, {
+              ...importOpts,
+              skipSelf: true,
+            });
+
+            if (resolved && !resolved.external) {
+              if (!isSideEffectFile(cleanUrl(resolved.id))) {
+                markoSideEffectImportIds.add(resolved.id);
+              }
+
+              if (isCssModule && cssModuleReg.test(resolved.id)) {
+                // The `.js` tail keeps vite's css pipeline off the facade.
+                return `${cssModuleFacadePrefix}${resolved.id}.js`;
+              }
+            }
           }
         }
 
@@ -870,7 +878,10 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
             return importee;
         }
 
-        if (virtualFiles.has(importee)) {
+        if (
+          virtualFiles.has(importee) ||
+          importee.endsWith(cssModuleStyleExt)
+        ) {
           return importee;
         }
 
@@ -984,6 +995,38 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
             return linkAssetsRuntimeCode;
           case noClientAssetsRuntimeId:
             return "NO_CLIENT_ASSETS";
+        }
+
+        if (rawId.startsWith(cssModuleFacadePrefix)) {
+          const file = rawId.slice(cssModuleFacadePrefix.length, -3);
+          return (
+            `import ${JSON.stringify(file + cssModuleStyleExt)};\n` +
+            `export * from ${JSON.stringify(file + "?transform-only")};\n` +
+            `export { default } from ${JSON.stringify(file + "?transform-only")};\n`
+          );
+        }
+
+        if (id.endsWith(cssModuleStyleExt)) {
+          // Serve the css module's compiled css as this plain css id's
+          // source, unwrapped from the string literal the `?inline` module
+          // default exports.
+          const inlineId = id.slice(0, -cssModuleStyleExt.length) + "?inline";
+          const { code } = await this.load({ id: inlineId });
+          if (code) {
+            for (const node of this.parse(code).body) {
+              if (
+                node.type === "ExportDefaultDeclaration" &&
+                node.declaration.type === "Literal" &&
+                typeof node.declaration.value === "string"
+              ) {
+                return node.declaration.value;
+              }
+            }
+          }
+
+          return this.error(
+            `@marko/vite: could not read the compiled css for ${inlineId}.`,
+          );
         }
 
         const info = getMarkoFileInfo(id);
@@ -1312,18 +1355,6 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
       apply: "build",
       enforce: "post", // We use a "post" plugin to allow us to read the final generated `.html` from vite.,
       sharedDuringBuild: true,
-      transform(_source, id, opts) {
-        if (!opts?.ssr && /\.module\.[^.]+(?:\?|$)/.test(id)) {
-          // CSS modules in vite tree shake, however when coupled with
-          // Marko (which leaves code on the server) this leads to no
-          // reference to the css module and causes it to be removed
-          // even when it should not be. Here we say all css moduleish
-          // files should not tree shake.
-          return {
-            moduleSideEffects: "no-treeshake",
-          };
-        }
-      },
       async generateBundle(outputOptions, bundle, isWrite) {
         if (!serverManifest) {
           return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1540,97 +1540,71 @@ function isMarkoFile(id: string) {
  * extracted the chunk is left with the bare `import "./other.js"` lines that
  * order it after its dependencies, which vite's own pure-css pass does not
  * recognise (it requires an entirely empty chunk), so every page shipped a
- * modulepreload for a script that does nothing. Those imports are already
- * satisfied by anything that imports the chunk, so it is removed and its
- * importers pick up its imports and stylesheet metadata directly.
+ * modulepreload for a script that does nothing. Each importer takes over the
+ * chunk's imports (in place, so side effect order holds) and its stylesheets.
  */
 function removeEmptyChunks(bundle: vite.Rollup.OutputBundle) {
   const chunks = Object.values(bundle).filter(
     (chunk) => chunk.type === "chunk",
   );
-  const dynamicallyImported = new Set<string>();
-  for (const chunk of chunks) {
-    for (const fileName of chunk.dynamicImports) {
-      dynamicallyImported.add(fileName);
-    }
-  }
-
-  const removed = new Set<string>();
+  const empty = new Map<string, vite.Rollup.OutputChunk>();
   for (const chunk of chunks) {
     if (
       !chunk.isEntry &&
       !chunk.isDynamicEntry &&
-      !chunk.exports.length &&
-      !dynamicallyImported.has(chunk.fileName) &&
-      // A chunk with no code at all is vite's pure css chunk to remove.
+      // Nothing but imports (a chunk with no code at all is left to vite).
       chunk.code.trim() &&
-      Object.values(chunk.modules).every((mod) => !mod.renderedLength) &&
-      !chunk.code.replace(emptyChunkImportReg, "").trim()
+      !chunk.code.replace(importStatementReg, "").trim()
     ) {
-      removed.add(chunk.fileName);
+      empty.set(chunk.fileName, chunk);
     }
   }
 
-  if (!removed.size) return;
+  if (!empty.size) return;
 
   for (const chunk of chunks) {
-    if (removed.has(chunk.fileName)) continue;
+    if (empty.has(chunk.fileName)) continue;
+    const dir = path.posix.dirname(chunk.fileName);
     const seen = new Set(chunk.imports);
-    const imports: string[] = [];
-    const visit = (fileName: string) => {
-      if (removed.has(fileName)) {
-        const empty = bundle[fileName] as vite.Rollup.OutputChunk;
-        for (const imported of empty.imports) visit(imported);
-        if (empty.viteMetadata && chunk.viteMetadata) {
-          for (const css of empty.viteMetadata.importedCss) {
+    chunk.code = chunk.code.replace(importStatementReg, (match, spec) => {
+      const dropped = empty.get(path.posix.join(dir, spec));
+      if (!dropped) return match;
+      const hoisted: string[] = [];
+      const visit = (dropped: vite.Rollup.OutputChunk) => {
+        if (dropped.viteMetadata && chunk.viteMetadata) {
+          for (const css of dropped.viteMetadata.importedCss) {
             chunk.viteMetadata.importedCss.add(css);
           }
-          for (const asset of empty.viteMetadata.importedAssets) {
+          for (const asset of dropped.viteMetadata.importedAssets) {
             chunk.viteMetadata.importedAssets.add(asset);
           }
         }
-      } else {
-        imports.push(fileName);
-      }
-    };
-
-    if (!chunk.imports.some((fileName) => removed.has(fileName))) continue;
-    for (const fileName of chunk.imports) visit(fileName);
-    chunk.imports = [...new Set(imports)];
-
-    const dir = path.posix.dirname(chunk.fileName);
-    const toSpecifier = (fileName: string) => {
-      const rel = path.posix.relative(dir, fileName);
-      return rel[0] === "." ? rel : "./" + rel;
-    };
-    chunk.code = chunk.code.replace(emptyChunkImportReg, (match, spec) => {
-      const fileName = path.posix.join(dir, spec);
-      if (!removed.has(fileName)) return match;
-      // Splice the dropped chunk's own imports in its place so the relative
-      // order of side effects is kept for anything not already imported.
-      const hoisted: string[] = [];
-      const visit = (fileName: string) => {
-        const empty = bundle[fileName] as vite.Rollup.OutputChunk;
-        for (const imported of empty.imports) {
-          if (removed.has(imported)) visit(imported);
-          else if (!seen.has(imported)) {
-            seen.add(imported);
-            hoisted.push(`import ${JSON.stringify(toSpecifier(imported))};`);
+        for (const fileName of dropped.imports) {
+          const nested = empty.get(fileName);
+          if (nested) visit(nested);
+          else if (!seen.has(fileName)) {
+            seen.add(fileName);
+            chunk.imports.push(fileName);
+            const rel = path.posix.relative(dir, fileName);
+            hoisted.push(
+              `import ${JSON.stringify(rel[0] === "." ? rel : "./" + rel)};`,
+            );
           }
         }
       };
-      visit(fileName);
+      visit(dropped);
       return hoisted.join("\n");
     });
+    chunk.imports = chunk.imports.filter((fileName) => !empty.has(fileName));
   }
 
-  for (const fileName of removed) {
+  for (const fileName of empty.keys()) {
     delete bundle[fileName];
     delete bundle[`${fileName}.map`];
   }
 }
 
-const emptyChunkImportReg = /^\s*import\s*["']([^"']+)["'];?[ \t]*$/gm;
+const importStatementReg = /^\s*import\s*["']([^"']+)["'];?[ \t]*$/gm;
 
 /**
  * Collects the css output files reachable from the chunk for the given

--- a/src/index.ts
+++ b/src/index.ts
@@ -1349,7 +1349,7 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
           meta: { markoAPI: meta.api },
         };
       },
-      renderChunk(code, chunk, _opts, meta) {
+      renderChunk(_code, chunk, _opts, meta) {
         // A css module's stylesheet is a side effect module, so a group of
         // them shared by some pages but not others gets its own chunk. Once
         // the css is extracted only the `import "./dep.js"` lines that order
@@ -1358,13 +1358,14 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
         // its stylesheets into each importer) only when its code is entirely
         // empty, so blank it when the imports are redundant: severing them is
         // safe once every importer already imports the same chunks itself.
+        // (An entirely empty chunk has no imports to sever and is vite's.)
         if (
           linked &&
           this.environment.name !== "ssr" &&
           !chunk.isEntry &&
           !chunk.isDynamicEntry &&
-          code.trim() &&
-          !code.replace(importStatementReg, "").trim() &&
+          !chunk.exports.length &&
+          Object.values(chunk.modules).every((mod) => !mod.renderedLength) &&
           Object.values(meta.chunks).every(
             (importer) =>
               !importer.imports.includes(chunk.fileName) ||
@@ -1549,8 +1550,6 @@ export default function markoPlugin(opts: Options = {}): vite.Plugin[] {
 function isMarkoFile(id: string) {
   return id.endsWith(markoExt);
 }
-
-const importStatementReg = /^\s*import\s*["']([^"']+)["'];?[ \t]*$/gm;
 
 /**
  * Collects the css output files reachable from the chunk for the given


### PR DESCRIPTION
Fixes #310.

A css module shared by two or more pages shipped an empty JS chunk, injected as a script into every page. The old `no-treeshake` marking kept the module's class name map — only read while rendering on the server — in the client graph, and vite never treats a chunk containing a `*.module.*` id as removable pure css.

In the client build a css module import now resolves to a small facade virtual that splits the file's two products: the class name map is re-exported from vite's own `?transform-only` view (tree shaken whenever the map goes unused) and the compiled css loads under a plain-css id vite bundles, links, and removes like any stylesheet. The blanket `no-treeshake` transform is deleted. A new fixture covers a css module shared by two pages with no client code; the test harness disables the modulepreload polyfill so those pages ship no JS at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01973i3U2FVSWs49sjMnPNTy