### PR TITLE
agent-feedback: SSR asset emission, link-rel inlining and README staleness

### DIFF
--- a/agent-feedback/items/2026-08-28-document-cspnonce-on-injected-asset-tags.md
+++ b/agent-feedback/items/2026-08-28-document-cspnonce-on-injected-asset-tags.md
@@ -1,0 +1,12 @@
+---
+type: dx
+impact: low
+effort: low
+site: README.md › # Linked Mode
+---
+
+# Say in the README that `$global.cspNonce` is applied to the asset tags linked mode injects
+
+Linked mode already nonces the tags it injects, and no doc says so, so a reader wiring a strict CSP over it has to render a page and read the markup to find out whether the injected assets are covered. `src/serializer.ts` pushes an `InjectType.AssetAttrs` slot on every `<script>`, every `<style>` and every `<link>` whose `rel` is `stylesheet` or `modulepreload` or whose `as` is `style` or `script`, and `src/link-assets.ts` plus `src/render-assets-runtime.ts` expand that slot to ` nonce="…"` whenever `g.cspNonce` is set. The README mentions neither `nonce` nor CSP anywhere, and website/docs/reference/template.md's `### $global.cspNonce` section enumerates only the tags the Marko runtime itself renders (`<html-script>`/`<html-style>`, the `<style>` rendered for a `<style>` tag with dynamic values, and the stream and resume inline scripts), an enumeration whose members are all `<script>` or `<style>` elements. Add a sentence under `# Linked Mode` naming the script, style and stylesheet/modulepreload `<link>` tags the plugin nonces, and a clause in that template.md section pointing at it. Keep the wording to those kinds: other `<link>` rels deliberately get no slot, since a nonce is inert there.
+
+Check: in a linked-mode app built with `vite build --app`, render with `Template.render({ $global: { cspNonce, serializedGlobals: ["cspNonce"] } }).pipe(res)` and `curl -s http://localhost:<port>/ | grep -o '<[a-z]*[^>]*nonce="[^"]*"[^>]*>'`; the injected `<link rel="stylesheet">`, `<link rel="modulepreload">` and `<script type="module">` all carry the nonce from the response's `Content-Security-Policy`. `grep -in 'nonce\|csp' README.md` exits 1 with no output.

--- a/agent-feedback/items/2026-08-28-document-dev-fouc-guard.md
+++ b/agent-feedback/items/2026-08-28-document-dev-fouc-guard.md
@@ -1,0 +1,12 @@
+---
+type: dx
+impact: low
+effort: low
+site: src/manifest-generator.ts › getPreventFOUCParts
+---
+
+# Document the dev-only `marko-vite-preload` FOUC guard and its no-JS consequence
+
+In dev, linked mode prepends a guard to every flushed asset group: `getPreventFOUCParts` emits `<style marko-vite-preload="<id>">html{visibility:hidden !important}</style>` plus an inline `async blocking=render type=module` script that awaits the entry modules and then removes both nodes. The mechanism is deliberate and dev-only by construction, but `marko-vite-preload`, `visibility:hidden` and `FOUC` appear in no README, website page or cheatsheet, so two consequences arrive unannounced. With JavaScript disabled, every dev page is blank, `document.documentElement` computing to `visibility: hidden` with the guard nodes still in the document, which reads as a broken app to anyone testing the promise in website/docs/explanation/targeted-compilation.md that Marko applications function completely without JavaScript. A whole-document comparison of served HTML against the hydrated DOM in dev also shows those two nodes as a delta that a production build does not produce, which sends people hunting a hydration mismatch. Add a sentence under README.md's `# Linked Mode` and in the marko-run `dev` docs naming the guard, the `marko-vite-preload` attribute to grep for, and its dev-only scope; emitting a `<noscript><style>html{visibility:visible !important}</style></noscript>` sibling would also make no-JS dev pages render.
+
+Check: run `marko-run dev` on an app, then `curl -s http://localhost:<port>/<route> | grep -o '<style marko-vite-preload[^>]*>[^<]*</style>'` prints `<style marko-vite-preload="dist_.marko-run_report.marko">html{visibility:hidden !important}</style>`, and `grep -ci noscript` on the same document prints 0. Loading that url with `javaScriptEnabled: false` reports `visibility` `hidden`, 2 guard nodes and an invisible `<h1>`; after `marko-run build && marko-run preview` the same route has no `marko-vite-preload` and reports `visibility` `visible`. `grep -rn -i 'marko-vite-preload\|visibility:hidden\|FOUC' README.md` exits 1.

--- a/agent-feedback/items/2026-08-28-emit-css-url-assets-from-server-only-templates.md
+++ b/agent-feedback/items/2026-08-28-emit-css-url-assets-from-server-only-templates.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: med
+effort: low
+site: src/index.ts › generateBundle
+---
+
+# Emit css `?url` assets referenced only from server-rendered templates
+
+An SSR build writes no assets, so `generateBundle`'s ssr branch collects asset module ids into `serverManifest.ssrAssetIds` and `transform` appends a side-effect `import` of each to the client entry, letting the client pass emit the files. The collector gates on `module?.meta["vite:asset"]`, which only Vite's `vite:asset` plugin sets, but `vite:css` is registered ahead of it and claims `*.css?url` in its own `load` hook, so a css `?url` module carries empty meta and never reaches `ssrAssetIds`. A `<link rel="stylesheet" media="print" href="./print.css?url">` in a server-only layout, which is exactly the spelling `# Browser asset references` in README.md prescribes to force a `.css` reference and exactly what `assetFileReg` in `src/relative-assets-transform.ts` matches, therefore compiles to a hashed `/assets/print-<hash>.css` href backed by no file: the build exits 0 with no warning and every request for that stylesheet 404s. A png referenced from the same `<link>` element in the same layout is emitted, which is why the `isomorphic-ssr-asset` fixture never caught this. Adding css `?url` ids to `ssrAssetIds` is not enough on its own, because the generated client-entry import is side-effect only and a css `?url` file is written only when its `__VITE_CSS_URL__` default export survives into a rendered chunk, so the fix has to reference the imported value or emit the file directly. Guard it with a fixture shaped like `isomorphic-relative-asset-import` whose `?url` stylesheet lives in a template that stays out of the client bundle.
+
+Check: in a linked-mode SSR app with `build.ssrEmitAssets` left at its default and a server-only layout containing `<link rel="stylesheet" media="print" href="./print.css?url">`, run `NODE_ENV=production vite build --app`; it exits 0 with no warning, `grep -o 'assets/print-[A-Za-z0-9_-]*\.css' dist/index.js` prints the reference (`assets/print-SKKTRJpX.css`), `ls dist/assets | grep print` prints nothing, and `curl -i http://localhost:<port>/assets/print-SKKTRJpX.css` against the built server returns `HTTP/1.1 404 Not Found`. Control: a 120 KB png referenced as `<link rel="preload" as="image" href="./big.png">` from the same layout does land in `dist/assets` and serves 200.

--- a/agent-feedback/items/2026-08-28-fix-readme-express-sample.md
+++ b/agent-feedback/items/2026-08-28-fix-readme-express-sample.md
@@ -1,0 +1,12 @@
+---
+type: dx
+impact: med
+effort: low
+site: README.md › # Linked Mode
+---
+
+# Fix the README's express sample and give `linked: false` a worked example
+
+The only server example in the README cannot parse, cannot run once it parses, and sends nothing once it runs: its `app.get("/", ...)` callback closes with `);` and no `}`, it imports `{ createServer } from "vite"` but calls `createViteServer(...)`, it calls `express()` without importing it, it omits `appType: "custom"` so Vite's default `spa` app type appends `indexHtmlMiddleware` and `notFoundMiddleware` to `vite.middlewares` and answers every request `404` with an empty body before the route runs, and `template.render({ hello: "world" }, res)` is Marko 5's two-argument signature that Marko 6 ignores, leaving the response open until something calls `.pipe(res)`. Since this is the one setup a linked-mode reader can copy, every one of those has to be rediscovered by hand. Two more stale spots sit in the same file: `### options.runtimeId` explains the option in terms of `window.$components`, a name no Marko 6 runtime uses (both key off `runtimeId`, whose default is `DEFAULT_RUNTIME_ID`), and the `linked: false` link under `# Linked Mode` points at `#options.linked` while GitHub slugs that heading `#optionslinked`, so it lands nowhere. Port the working equivalent from website/docs/introduction/installation.md, repair the anchor and the `$components` sentence, and give `### options.linked` a worked `linked: false` config, a thing that appears in no page of this README, the website docs, either cheatsheet, or marko-js/examples beyond a one-line aside in website/docs/reference/lazy-loading.md.
+
+Check: copy the fenced `js` block under `# Linked Mode` into `/tmp/sample.mjs` and run `node --check /tmp/sample.mjs`; it prints `SyntaxError: Unexpected token ')'`. Repair only the missing `}`, the `createViteServer` name and the express import, run it, and `curl -i http://localhost:3000/` returns `HTTP/1.1 404 Not Found` with `Content-Length: 0` while the route body never executes; adding `appType: "custom"` reaches the route, which then never responds. `node -e 'console.log(new (require("github-slugger").default)().slug("options.linked"))'` prints `optionslinked`.

--- a/agent-feedback/items/2026-08-28-skip-inlining-icon-and-manifest-link-assets.md
+++ b/agent-feedback/items/2026-08-28-skip-inlining-icon-and-manifest-link-assets.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: low
+effort: low
+site: src/relative-assets-transform.ts › transform
+---
+
+# Skip inlining for relative `<link rel=icon|apple-touch-icon|manifest>` assets, as Vite's HTML pipeline does
+
+`transform` rewrites a static relative asset attribute into a plain Vite asset import without consulting the tag's `rel`, so `<link rel=icon href="./favicon.png">`, `rel=apple-touch-icon` and `rel=manifest` all fall through to Vite's size-only `shouldInline` (`build.assetsInlineLimit`, default 4096 bytes, with no rel and no SSR exception) and are base64-inlined into the SSR chunk. Vite's own HTML pipeline refuses to inline those rels on purpose, keeping `icon`, `apple-touch-icon`, `apple-touch-startup-image` and `manifest` in its `noInlineLinkRels` set, so the same 2.3 KB favicon that stays a hashed file in an `index.html` build becomes a 3.1 KB `data:` URI sitting in the head of every HTML response, uncacheable and charged to the first packet, and a `.webmanifest` is served as `data:application/manifest+json;base64,…`. Mirror Vite: when the tag is `link` and its static `rel` is one of those four, emit the generated import with `?no-inline`. That query is safe to add unconditionally, since `src/query.ts` already passes `no-inline` through and the package's peer range is `vite: ^8`. While fixing it, name the inline threshold and its two opt-outs (`?no-inline` on the reference, `build.assetsInlineLimit`) in README.md's `# Browser asset references`, which shows a hashed-file output as the result and says nothing about inlining.
+
+Check: in a linked-mode SSR app with `build.assetsInlineLimit` unset whose server-rendered layout has `<link rel=icon type=image/png sizes=32x32 href="./favicon.png">` (2310 bytes) and `<link rel=manifest href="./site.webmanifest">`, run `NODE_ENV=production vite build --app`; `grep -c 'data:image/png;base64' dist/index.js` prints 1, `ls dist/assets | grep -i favicon` prints nothing, and the served page carries `<link rel=icon … href=data:image/png;base64,…>` (3150 bytes, starting 575 bytes into the document; 3448 of its 8555 bytes are base64) plus `<link rel=manifest href=data:application/manifest+json;base64,…>`. Control: the same favicon.png in a plain `index.html` built by vite with default config stays `<link rel=icon … href="/assets/favicon-DH_FVca_.png">` while an `<img src="./favicon.png">` in that same document inlines. Writing `href="./favicon.png?no-inline"` in the layout yields 0 png data URIs and emits `dist/assets/favicon-DH_FVca_.png`.


### PR DESCRIPTION
Files five items.

A css `?url` asset referenced only from server-rendered markup is never emitted in a linked SSR build, so the page requests a file the build did not write. Relative `<link rel=icon|apple-touch-icon|manifest>` assets are base64-inlined, which Vite HTML pipeline skips for those rels. The rest document `$global.cspNonce` reaching the asset tags linked mode injects, the dev-only `marko-vite-preload` FOUC guard and its no-JS consequence, and a README express sample that cannot run as written.